### PR TITLE
COS-499: Background crash has active assertions beyond permitted time

### DIFF
--- a/Classes/RZCoreDataStack.m
+++ b/Classes/RZCoreDataStack.m
@@ -404,7 +404,7 @@ static NSString* const kRZCoreDataStackParentStackKey = @"RZCoreDataStackParentS
         
         __block UIBackgroundTaskIdentifier backgroundPurgeTaskID = UIBackgroundTaskInvalid;
         
-        [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
+        backgroundPurgeTaskID = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
             [[UIApplication sharedApplication] endBackgroundTask:backgroundPurgeTaskID];
             backgroundPurgeTaskID = UIBackgroundTaskInvalid;
         }];


### PR DESCRIPTION
- Background task was not being assigned to an ID, so it was never being ended.
