### PR TITLE
Fix a bug in rzv_objectInContext:

### DIFF
--- a/Classes/NSManagedObject+RZVinylUtils.m
+++ b/Classes/NSManagedObject+RZVinylUtils.m
@@ -24,7 +24,7 @@
     }
     
     if ( context == self.managedObjectContext ) {
-        return nil;
+        return self;
     }
     
     if ( [self.objectID isTemporaryID] ) {


### PR DESCRIPTION
Return self instead of nil if the context is the same.
