### PR TITLE
Remove Test Code

### DIFF
--- a/Classes/RZCoreDataStack.h
+++ b/Classes/RZCoreDataStack.h
@@ -249,10 +249,4 @@ typedef NS_OPTIONS(NSUInteger, RZCoreDataStackOptions)
  */
 - (void)purgeStaleObjectsWithCompletion:(void(^)(NSError *err))completion;
 
-/**
- *  Block the current thread until all currently dispatched background operations complete.  This can be
- *  helpful in test code to synchronize timing, but should otherwise be avoided.
- */
-- (void)blockThreadUntilBackgroundQueueCompletes;
-
 @end

--- a/Classes/RZCoreDataStack.m
+++ b/Classes/RZCoreDataStack.m
@@ -428,11 +428,6 @@ static NSString* const kRZCoreDataStackParentStackKey = @"RZCoreDataStackParentS
     }];
 }
 
-- (void)blockThreadUntilBackgroundQueueCompletes
-{
-    dispatch_sync(self.backgroundContextQueue, ^{});
-}
-
 @end
 
 //=====================

--- a/Example/RZVinylTests/RZVinylSaveTests.m
+++ b/Example/RZVinylTests/RZVinylSaveTests.m
@@ -148,17 +148,4 @@
                }];
 }
 
-- (void)testBlocking
-{
-    __block NSUInteger i = 0;
-    [self.coreDataStack performBlockUsingBackgroundContext:^(NSManagedObjectContext *context) {
-        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
-        i += 1;
-    } completion:^(NSError *err) {
-    }];
-    [self.coreDataStack blockThreadUntilBackgroundQueueCompletes];
-    XCTAssertTrue(i == 1, @"The background thread has not completed");
-}
-
-
 @end


### PR DESCRIPTION
Made a PR that added a helper blocking method for test code to use.  This removes that, as the same functionality can be achieved by submitting a background block and spinning the runloop in the test code.
