### PR TITLE
Move name assertion

### DIFF
--- a/Classes/RZCoreDataStack.m
+++ b/Classes/RZCoreDataStack.m
@@ -285,14 +285,14 @@ static NSString* const kRZCoreDataStackParentStackKey = @"RZCoreDataStackParentS
 
 - (BOOL)buildStack
 {
-    if ( !RZVAssert(self.modelName != nil, @"Must have a model name") ) {
-        return NO;
-    }
-    
     //
     // Create model
     //
     if ( self.managedObjectModel == nil ) {
+        if ( !RZVAssert(self.modelName != nil, @"Must have a model name") ) {
+            return NO;
+        }
+        
         self.managedObjectModel = [[NSManagedObjectModel alloc] initWithContentsOfURL:[[NSBundle mainBundle] URLForResource:self.modelName withExtension:@"momd"]];
         if ( self.managedObjectModel == nil ) {
             RZVLogError(@"Could not create managed object model for name %@", self.modelName);


### PR DESCRIPTION
Implemented:
- Move the assertion for model name to a slightly different location. As it stands, this assertion was triggering when initializing directly with an `NSManagedObjectModel`, which made it impossible to test in logical unit test bundles.
