### PR TITLE
Fall back on CFBundleName

### DIFF
--- a/Classes/RZCoreDataStack.m
+++ b/Classes/RZCoreDataStack.m
@@ -230,7 +230,8 @@ static NSString* const kRZCoreDataStackParentStackKey = @"RZCoreDataStackParentS
 - (NSString *)modelName
 {
     if ( _modelName == nil ) {
-        NSMutableString *productName = [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] mutableCopy];
+        // Fall back on CFBundleName if CFBundleDisplayName is not included in info.plist
+        NSMutableString *productName = [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] mutableCopy] ?: [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"] mutableCopy];
         [productName replaceOccurrencesOfString:@" " withString:@"_" options:0 range:NSMakeRange(0, productName.length)];
         [productName replaceOccurrencesOfString:@"-" withString:@"_" options:0 range:NSMakeRange(0, productName.length)];
         _modelName = [NSString stringWithString:productName];


### PR DESCRIPTION
Another small one :)

According to the documentation, CFBundleDisplayName is optional; only to be used if you are localizing your bundle (which is obviously a good idea to do). 

https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-110725

`If you do not intend to localize your bundle, do not include this key in your Info.plist file. Inclusion of this key does not affect the display of the bundle name but does incur a performance penalty to search for localized versions of this key.`

`CFBundleDisplayName` does not appear to come as a default key with new projects, whereas `CFBundleName` does.

