### PR TITLE
cull duplicates in array imports

### DIFF
--- a/Example/RZVinylTests/RZVinylImportTests.m
+++ b/Example/RZVinylTests/RZVinylImportTests.m
@@ -197,21 +197,24 @@
 {
     const NSUInteger count = 1000;
     
-    NSDictionary *templateDict = @{
+    NSDictionary *artistTemplate = @{
        @"name" : @"Rick Astley",
        @"genre" : @"Pop",
-       @"songs" : @[
-          @{
-              @"id" : @1337,
-              @"title" : @"Never Gonna Give You Up"
-           }
-       ]
     };
+
+    NSDictionary *songTemplate = @{
+        @"title" : @"Never Gonna Give You Up"
+    };
+
     
     NSMutableArray *artistArray = [NSMutableArray array];
     for ( NSUInteger i = 0; i < count; i++ ) {
-        NSMutableDictionary *artistDict = [templateDict mutableCopy];
-        [artistDict setObject:@(i+1) forKey:@"id"];
+        NSMutableDictionary *songDict = [songTemplate mutableCopy];
+        [songDict   setObject:@(1000+i) forKey:@"id"];
+
+        NSMutableDictionary *artistDict = [artistTemplate mutableCopy];
+        [artistDict setObject:@(i+1)    forKey:@"id"];
+        [artistDict setObject:@[songDict] forKey:@"songs"];
         [artistArray addObject:artistDict];
     }
     

--- a/Extensions/NSManagedObject+RZImport.m
+++ b/Extensions/NSManagedObject+RZImport.m
@@ -131,7 +131,7 @@
     }
     else if ( [self rzv_safe_primaryKey] != nil ) {
     
-        NSMutableArray *updatedObjects = [NSMutableArray array];
+        NSMutableDictionary *updatedObjects = [NSMutableDictionary dictionary];
         
         NSString *externalPrimaryKey = [self rzv_safe_externalPrimaryKey] ?: [self rzv_safe_primaryKey];
         
@@ -143,8 +143,12 @@
             
             if ( primaryValue != nil ) {
                 importedObject = [existingObjectsByID objectForKey:primaryValue];
+
+                 if (importedObject==nil) {
+                     importedObject = [updatedObjects objectForKey:primaryValue];
+                 }
             }
-            
+
             if ( importedObject == nil ) {
                 importedObject = [self rzv_newObjectInContext:context];
             }
@@ -152,11 +156,11 @@
             [importedObject rzi_importValuesFromDict:rawDict inContext:context withMappings:mappings];
             
             if ( importedObject != nil ) {
-                [updatedObjects addObject:importedObject];
+                [updatedObjects setObject:importedObject forKey:primaryValue];
             }
         }];
         
-        objects = [NSArray arrayWithArray:updatedObjects];
+        objects = [updatedObjects allValues];
     }
     else {
         // Default to creating new object instances.


### PR DESCRIPTION
If you import the same object (as defined by 'A.primary-key == B.primary-key') in two separate operations, you can expect the values from B to modify the existing object, A.

When importing an array, the check for 'same primary-key' was using only the objects that existed before the array started getting imported.  If the array being imported contained multiple objects with the same key, all of them would be imported.  

This fix unmasked another bug, in test_BigImport_1000.  The test was importing multiple artists, all owning the same song, and expecting the song to belong to all of them.  What was happening is that, due to the to-one-ness of the song's relationship to its artist, the song ended up being owned by the last artist imported, all other artists ended up owning no songs.  The test was checking [array lastObject], which may not have been the last song imported.  I'm don't know why the test worked before, or why my fix unmasked this bug, I'd be happy to have someone explain it to me.
