### PR TITLE
Added limit to `rzv_where:... ` calls

### DIFF
--- a/Classes/NSManagedObject+RZVinylRecord.h
+++ b/Classes/NSManagedObject+RZVinylRecord.h
@@ -161,6 +161,16 @@
 + (NSArray *)rzv_where:(NSPredicate *)predicate;
 
 /**
+ *  Return the results of a fetch on the main context using a predicate or format string.
+ *
+ *  @param predicate    An @p NSPredicate to filter the query. Passing nil will return all objects.
+ *  @param limit            The limit of the returning objects. 0 if all
+ *
+ *  @return The results of the fetch.
+ */
++ (NSArray *)rzv_where:(NSPredicate *)predicate limit:(NSUInteger)limit;
+
+/**
  *  Return the results of a fetch on the provided context using a predicate or format string.
  *
  *  @param predicate        An @p NSPredicate to filter the query. Passing nil will return all objects.
@@ -169,6 +179,17 @@
  *  @return The results of the fetch.
  */
 + (NSArray *)rzv_where:(NSPredicate *)predicate inContext:(NSManagedObjectContext *)context;
+
+/**
+ *  Return the results of a fetch on the provided context using a predicate or format string.
+ *
+ *  @param predicate        An @p NSPredicate to filter the query. Passing nil will return all objects.
+ *  @param context          The managed object context on which to perform the fetch. Must not be nil.
+ *  @param limit            The limit of the returning objects. 0 if all
+ *
+ *  @return The results of the fetch.
+ */
++ (NSArray *)rzv_where:(NSPredicate *)predicate limit:(NSUInteger)limit inContext:(NSManagedObjectContext *)context;
 
 /**
  *  Return the results of a fetch on the main context using a predicate or format string
@@ -182,6 +203,18 @@
 + (NSArray *)rzv_where:(NSPredicate *)predicate sort:(NSArray *)sortDescriptors;
 
 /**
+ *  Return the results of a fetch on the main context using a predicate or format string
+ *  with optional sorting.
+ *
+ *  @param predicate        An @p NSPredicate to filter the query. Passing nil will return all objects.
+ *  @param sortDescriptors  An optional array of sort descriptors.
+ *  @param limit            The limit of the returning objects. 0 if all
+ *
+ *  @return The results of the fetch.
+ */
++ (NSArray *)rzv_where:(NSPredicate *)predicate sort:(NSArray *)sortDescriptors limit:(NSUInteger)limit;
+
+/**
  *  Return the results of a fetch on the provided context using a predicate or format string
  *  with optional sorting.
  *
@@ -193,6 +226,22 @@
  */
 + (NSArray *)rzv_where:(NSPredicate *)predicate
                   sort:(NSArray *)sortDescriptors
+             inContext:(NSManagedObjectContext *)context;
+
+/**
+ *  Return the results of a fetch on the provided context using a predicate or format string
+ *  with optional sorting.
+ *
+ *  @param predicate        An @p NSPredicate to filter the query. Passing nil will return all objects.
+ *  @param sortDescriptors  An optional array of sort descriptors.
+ *  @param limit            The limit of the returning objects. 0 if all
+ *  @param context          The managed object context on which to perform the fetch. Must not be nil.
+ *
+ *  @return The results of the fetch.
+ */
++ (NSArray *)rzv_where:(NSPredicate *)predicate
+                  sort:(NSArray *)sortDescriptors
+                 limit:(NSUInteger)limit
              inContext:(NSManagedObjectContext *)context;
 
 

--- a/Classes/NSManagedObject+RZVinylRecord.m
+++ b/Classes/NSManagedObject+RZVinylRecord.m
@@ -164,12 +164,27 @@
     return [self rzv_where:predicate sort:nil];
 }
 
++ (NSArray *)rzv_where:(NSPredicate *)predicate limit:(NSUInteger)limit
+{
+    return [self rzv_where:predicate sort:nil limit:limit];
+}
+
 + (NSArray *)rzv_where:(NSPredicate *)predicate inContext:(NSManagedObjectContext *)context
 {
     return [self rzv_where:predicate sort:nil inContext:context];
 }
 
++ (NSArray *)rzv_where:(NSPredicate *)predicate limit:(NSUInteger)limit inContext:(NSManagedObjectContext *)context
+{
+    return [self rzv_where:predicate sort:nil limit:limit inContext:context];
+}
+
 + (NSArray *)rzv_where:(NSPredicate *)predicate sort:(NSArray *)sortDescriptors
+{
+    return [self rzv_where:predicate sort:sortDescriptors limit:0];
+}
+
++ (NSArray *)rzv_where:(NSPredicate *)predicate sort:(NSArray *)sortDescriptors limit:(NSUInteger)limit
 {
     if ( !RZVAssertMainThread() ) {
         return nil;
@@ -178,16 +193,22 @@
     if ( stack == nil ){
         return nil;
     }
-    return [self rzv_where:predicate sort:sortDescriptors inContext:[stack mainManagedObjectContext]];
+    return [self rzv_where:predicate sort:sortDescriptors limit:limit inContext:[stack mainManagedObjectContext]];
 }
 
 + (NSArray *)rzv_where:(NSPredicate *)predicate sort:(NSArray *)sortDescriptors inContext:(NSManagedObjectContext *)context
+{
+    return [self rzv_where:predicate sort:sortDescriptors limit:0 inContext:context];
+}
+
++ (NSArray *)rzv_where:(NSPredicate *)predicate sort:(NSArray *)sortDescriptors limit:(NSUInteger)limit inContext:(NSManagedObjectContext *)context
 {
     NSError *error = nil;
     NSFetchRequest *fetch = [NSFetchRequest rzv_forEntity:[self rzv_entityName]
                                                 inContext:context
                                                     where:predicate
                                                      sort:sortDescriptors];
+    fetch.fetchLimit = limit;
     
     NSArray *fetchedObjects = [context executeFetchRequest:fetch error:&error];
     if ( error ) {

--- a/Example/RZVinylTests/RZVinylRecordTests.m
+++ b/Example/RZVinylTests/RZVinylRecordTests.m
@@ -310,6 +310,29 @@
     XCTAssertEqual(artistsWithSongsCount, 2, @"Should be two artists with songs");
 }
 
+- (void)test_LimitObjects
+{
+    NSPredicate *emptyPredicate = [NSPredicate predicateWithValue:YES];
+    // Get all artists who have songs
+    NSArray *artists = [Artist rzv_where:emptyPredicate limit:1];
+    XCTAssertEqual(artists.count, 1, @"Should be limited to 1 artist");
+
+    // Get all artists who have songs sorted by name
+    NSArray *expectedNames = @[@"BCee", @"Dusky"];
+
+    artists = [Artist rzv_where:emptyPredicate sort:@[RZVKeySort(@"name", YES)] limit:2];
+    XCTAssertEqual(artists.count, 2, @"Should be limited to 2 artists sorted");
+    XCTAssertEqualObjects(expectedNames, [artists valueForKey:@"name"], @"Not in correct order");
+
+    // Try on child context
+    NSManagedObjectContext *scratchContext = [self.stack backgroundManagedObjectContext];
+    artists = [Artist rzv_where:emptyPredicate limit:2 inContext:scratchContext];
+    XCTAssertEqual(artists.count, 2, @"Should be two artists with songs");
+
+    artists = [Artist rzv_where:emptyPredicate sort:@[RZVKeySort(@"name", YES)] limit:2 inContext:scratchContext];
+    XCTAssertEqual(artists.count, 2, @"Should be two artists with songs");
+}
+
 - (void)test_Delete
 {
     Artist *dusky = [Artist rzv_objectWithPrimaryKeyValue:@1000 createNew:NO];
@@ -429,7 +452,7 @@
         
         NSArray *artists = [Artist rzv_allInContext:context];
         XCTAssertEqual(artists.count, 3, @"Should be three artists to start");
-        
+
         [Artist rzv_deleteAllInContext:context];
         artists = [Artist rzv_allInContext:context];
         XCTAssertEqual(artists.count, 0, @"Should be no artists after delete all");


### PR DESCRIPTION
- Adds a fetch limit to rzv_where calls on NSManagedObject
- Adds tests to make sure the baseline is working.