### PR TITLE
The user info is getting set outside of it's queue

### DIFF
--- a/Classes/RZCoreDataStack.m
+++ b/Classes/RZCoreDataStack.m
@@ -191,7 +191,9 @@ static NSString* const kRZCoreDataStackParentStackKey = @"RZCoreDataStackParentS
 - (NSManagedObjectContext *)backgroundManagedObjectContext
 {
     NSManagedObjectContext *bgContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
-    [[bgContext userInfo] setObject:self forKey:kRZCoreDataStackParentStackKey];
+    [bgContext performBlockAndWait:^{
+        [[bgContext userInfo] setObject:self forKey:kRZCoreDataStackParentStackKey];
+    }];
     bgContext.parentContext = self.topLevelBackgroundContext;
     [self registerSaveNotificationsForContext:bgContext];
     return bgContext;


### PR DESCRIPTION
When turning on concurrency debugging this line of code would break because the user info is getting set outside of it's queue (per @mgorbach ). 