### PR TITLE
Adding missing UIKit import

### DIFF
--- a/Classes/RZCoreDataStack.m
+++ b/Classes/RZCoreDataStack.m
@@ -26,6 +26,7 @@
 //  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 //  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+@import UIKit.UIApplication;
 
 #import "RZCoreDataStack.h"
 #import "NSManagedObject+RZVinylRecord.h"


### PR DESCRIPTION
We access a few UIKit methods in RZCoreDataStack which breaks this if you aren't using Cocoapods.  
