### PR TITLE
Replace reserved keyword for Swift compatibility

### DIFF
--- a/Classes/NSFetchRequest+RZVinylRecord.h
+++ b/Classes/NSFetchRequest+RZVinylRecord.h
@@ -43,7 +43,7 @@
  */
 + (instancetype)rzv_forEntity:(NSString *)entityName
                     inContext:(NSManagedObjectContext *)context
-                        where:(NSPredicate *)predicate
+                        predicate:(NSPredicate *)predicate
                          sort:(NSArray *)sortDescriptors;
 
 @end

--- a/Classes/NSFetchRequest+RZVinylRecord.m
+++ b/Classes/NSFetchRequest+RZVinylRecord.m
@@ -34,7 +34,7 @@
 
 + (instancetype)rzv_forEntity:(NSString *)entityName
                     inContext:(NSManagedObjectContext *)context
-                        where:(NSPredicate *)predicate
+                        predicate:(NSPredicate *)predicate
                          sort:(NSArray *)sortDescriptors
 {
     if ( !RZVParameterAssert(entityName) || !RZVParameterAssert(context) ) {

--- a/Classes/NSFetchedResultsController+RZVinylRecord.h
+++ b/Classes/NSFetchedResultsController+RZVinylRecord.h
@@ -44,7 +44,7 @@
  */
 + (instancetype)rzv_forEntity:(NSString *)entityName
                     inContext:(NSManagedObjectContext *)context
-                        where:(NSPredicate *)predicate
+                        predicate:(NSPredicate *)predicate
                          sort:(NSArray *)sortDescriptors;
 
 /**
@@ -61,7 +61,7 @@
  */
 + (instancetype)rzv_forEntity:(NSString *)entityName
                     inContext:(NSManagedObjectContext *)context
-                        where:(NSPredicate *)predicate
+                        predicate:(NSPredicate *)predicate
                          sort:(NSArray *)sortDescriptors
            sectionNameKeyPath:(NSString *)sectionNameKeyPath
                     cacheName:(NSString *)cacheName;

--- a/Classes/NSFetchedResultsController+RZVinylRecord.m
+++ b/Classes/NSFetchedResultsController+RZVinylRecord.m
@@ -35,12 +35,12 @@
 
 + (instancetype)rzv_forEntity:(NSString *)entityName
                     inContext:(NSManagedObjectContext *)context
-                        where:(NSPredicate *)predicate
+                        predicate:(NSPredicate *)predicate
                          sort:(NSArray *)sortDescriptors
 {
     return [self rzv_forEntity:entityName
                      inContext:context
-                         where:predicate
+                         predicate:predicate
                           sort:sortDescriptors
             sectionNameKeyPath:nil
                      cacheName:nil];
@@ -48,7 +48,7 @@
 
 + (instancetype)rzv_forEntity:(NSString *)entityName
                     inContext:(NSManagedObjectContext *)context
-                        where:(NSPredicate *)predicate
+                        predicate:(NSPredicate *)predicate
                          sort:(NSArray *)sortDescriptors
            sectionNameKeyPath:(NSString *)sectionNameKeyPath
                     cacheName:(NSString *)cacheName
@@ -59,7 +59,7 @@
     
     NSFetchRequest *fetch = [NSFetchRequest rzv_forEntity:entityName
                                                 inContext:context
-                                                    where:predicate
+                                                    predicate:predicate
                                                      sort:sortDescriptors];
     
     return [[NSFetchedResultsController alloc] initWithFetchRequest:fetch

--- a/Classes/NSManagedObject+RZVinylRecord.m
+++ b/Classes/NSManagedObject+RZVinylRecord.m
@@ -119,7 +119,7 @@
     
     NSFetchRequest *fetch = [NSFetchRequest rzv_forEntity:[self rzv_entityName]
                                                 inContext:context
-                                                    where:[NSCompoundPredicate andPredicateWithSubpredicates:predicates]
+                                                    predicate:[NSCompoundPredicate andPredicateWithSubpredicates:predicates]
                                                      sort:nil];
     NSError *error = nil;
     id result = [[context executeFetchRequest:fetch error:&error] lastObject];
@@ -191,7 +191,7 @@
     NSError *error = nil;
     NSFetchRequest *fetch = [NSFetchRequest rzv_forEntity:[self rzv_entityName]
                                                 inContext:context
-                                                    where:predicate
+                                                    predicate:predicate
                                                      sort:sortDescriptors];
     
     NSArray *fetchedObjects = [context executeFetchRequest:fetch error:&error];
@@ -232,7 +232,7 @@
 {
     NSFetchRequest *fetch = [NSFetchRequest rzv_forEntity:[self rzv_entityName]
                                                 inContext:context
-                                                    where:predicate
+                                                    predicate:predicate
                                                      sort:nil];
     
     [fetch setResultType:NSCountResultType];

--- a/Example/RZVinylDemo/Data/Sources/RZFetchedPersonDataSource.m
+++ b/Example/RZVinylDemo/Data/Sources/RZFetchedPersonDataSource.m
@@ -35,7 +35,7 @@ static NSString* const kRZPeronDataSourcePersonCellIdentifier = @"PersonCell";
 
         _fetchedResultsController = [NSFetchedResultsController rzv_forEntity:[RZPerson rzv_entityName]
                                                                     inContext:[[RZCoreDataStack defaultStack] mainManagedObjectContext]
-                                                                        where:nil
+                                                                        predicate:nil
                                                                          sort:@[ RZVKeySort(NSStringFromSelector(@selector(sortIndex)), NO) ]];
         _fetchedResultsController.delegate = self;
         [self updateFetch];

--- a/Extensions/NSManagedObject+RZImport.h
+++ b/Extensions/NSManagedObject+RZImport.h
@@ -28,7 +28,7 @@
 
 
 @import CoreData;
-#import "NSObject+RZImport.h"
+#import <RZImport/NSObject+RZImport.h>
 
 /**
  *  Automatic importing of dictionary representations (e.g. deserialized JSON response) 


### PR DESCRIPTION
`where` is a reserved keyword in Swift

Note: I also changed the import path in `NSManagedObject+RZImport.h` which doesn't work when installing from cocoapods (might just be a swift thing) -> I can extract this into another PR if that's preferable. 