### PR TITLE
Have `+defaultStack` return instancetype instead of RZCoreDataStack

### DIFF
--- a/Classes/RZCoreDataStack.h
+++ b/Classes/RZCoreDataStack.h
@@ -92,7 +92,7 @@ typedef NS_OPTIONS(NSUInteger, RZCoreDataStackOptions)
  *
  *  @return The default @p RZCoreDataStack for this application.
  */
-+ (RZCoreDataStack *)defaultStack;
++ (instancetype)defaultStack;
 
 /**
  *  Set the default Core Data stack for this application.

--- a/Classes/RZCoreDataStack.m
+++ b/Classes/RZCoreDataStack.m
@@ -66,11 +66,11 @@ static NSString* const kRZCoreDataStackParentStackKey = @"RZCoreDataStackParentS
 {
     if ( s_defaultStack == nil ) {
         RZVLogInfo(@"The default stack has been accessed without being configured. Creating a new default stack with the default options.");
-        s_defaultStack = [[RZCoreDataStack alloc] initWithModelName:nil
-                                                      configuration:nil
-                                                          storeType:nil
-                                                           storeURL:nil
-                                                            options:kNilOptions];
+        s_defaultStack = [[self alloc] initWithModelName:nil
+                                           configuration:nil
+                                               storeType:nil
+                                                storeURL:nil
+                                                 options:kNilOptions];
     }
     return s_defaultStack;
 }


### PR DESCRIPTION
There's a common pattern to subclass RZCoreDataStack as a place to put model, but non entity specific application behaviors. This just makes the singleton storage able to reflect that type information.