### PR TITLE
Notification Safety

### DIFF
--- a/Extensions/NSManagedObject+RZImport.m
+++ b/Extensions/NSManagedObject+RZImport.m
@@ -144,7 +144,7 @@
             if ( primaryValue != nil ) {
                 importedObject = [existingObjectsByID objectForKey:primaryValue];
 
-                 if (importedObject==nil) {
+                 if (importedObject == nil) {
                      importedObject = [updatedObjects objectForKey:primaryValue];
                  }
             }


### PR DESCRIPTION
This was the simplest solution for #34. It doesn't fix the root of the problem (the object not being un-subscribed), but it also shouldn't be an issue in iOS9 where objects are automatically un-subscribed.

