### PR TITLE
Remove context from RZImportable instance methods

### DIFF
--- a/Classes/RZCoreDataStack.m
+++ b/Classes/RZCoreDataStack.m
@@ -195,7 +195,12 @@ static RZCoreDataStack *s_defaultStack = nil;
 {
     NSManagedObjectContext *bgContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
     [[bgContext userInfo] setObject:self forKey:kRZCoreDataStackParentStackKey];
-    bgContext.parentContext = self.topLevelBackgroundContext;
+    if (self.topLevelBackgroundContext) {
+        bgContext.parentContext = self.topLevelBackgroundContext;
+    }
+    else {
+        bgContext.persistentStoreCoordinator = self.persistentStoreCoordinator;
+    }
     [self registerSaveNotificationsForContext:bgContext];
     return bgContext;
 }

--- a/Example/RZVinylDemo/Data/Model/Extensions/RZPerson+RZVinyl.m
+++ b/Example/RZVinylDemo/Data/Model/Extensions/RZPerson+RZVinyl.m
@@ -21,7 +21,7 @@
     return @"id";
 }
 
-- (BOOL)rzi_shouldImportValue:(id)value forKey:(NSString *)key inContext:(NSManagedObjectContext *)context
+- (BOOL)rzi_shouldImportValue:(id)value forKey:(NSString *)key
 {
     if ( [key isEqualToString:@"interests"] ) {
         if ( [value isKindOfClass:[NSArray class]] ) {
@@ -29,7 +29,7 @@
             NSMutableSet *interests = [NSMutableSet set];
             [(NSArray *)value enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
                 if ( [obj isKindOfClass:[NSString class]] ) {
-                    RZInterest *interest = [RZInterest rzv_objectWithAttributes:@{ @"name" : obj } createNew:YES inContext:context];
+                    RZInterest *interest = [RZInterest rzv_objectWithAttributes:@{ @"name" : obj } createNew:YES inContext:self.managedObjectContext];
                     if ( interest ) {
                         [interests addObject:interest];
                     }
@@ -39,7 +39,7 @@
         }
         return NO;
     }
-    return [super rzi_shouldImportValue:value forKey:key inContext:context];
+    return [super rzi_shouldImportValue:value forKey:key];
 }
 
 @end

--- a/Example/RZVinylTests/RZVinylImportTests.m
+++ b/Example/RZVinylTests/RZVinylImportTests.m
@@ -170,7 +170,7 @@
         
         Artist *huxley = [Artist rzv_newObjectInContext:context];
         XCTAssertEqualObjects(huxley.managedObjectContext, context, @"Wrong context");
-        XCTAssertNoThrow([huxley rzi_importValuesFromDict:artistDict inContext:context], @"Direct import should not throw exception");
+        XCTAssertNoThrow([huxley rzi_importValuesFromDict:artistDict], @"Direct import should not throw exception");
         XCTAssertEqualObjects(huxley.name, @"Huxley", @"Name import failed");
 
         XCTAssertTrue(huxley.songs.count == 2, @"Song import failed");

--- a/Example/RZVinylTests/RZVinylImportTests.m
+++ b/Example/RZVinylTests/RZVinylImportTests.m
@@ -260,7 +260,9 @@
     NSTimeInterval start = [NSDate timeIntervalSinceReferenceDate];
     __block NSTimeInterval finish = 0;
     [[RZCoreDataStack defaultStack] performBlockUsingBackgroundContext:^(NSManagedObjectContext *context) {
-        [Artist rzi_objectsFromArray:artistArray inContext:context];
+        [context rzi_performImport:^{
+            [Artist rzi_objectsFromArray:artistArray];
+        }];
     } completion:^(NSError *err) {
         finish = [NSDate timeIntervalSinceReferenceDate];
         [saveExpectation fulfill];

--- a/Extensions/NSManagedObject+RZImport.h
+++ b/Extensions/NSManagedObject+RZImport.h
@@ -29,7 +29,12 @@
 
 @import CoreData;
 #import "RZVCompatibility.h"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wauto-import"
 #import <RZImport/NSObject+RZImport.h>
+#pragma clang diagnostic pop
+
 
 /**
  *  Automatic importing of dictionary representations (e.g. deserialized JSON response) 

--- a/Extensions/NSManagedObject+RZImport.h
+++ b/Extensions/NSManagedObject+RZImport.h
@@ -33,9 +33,12 @@
 
 /**
  *  Automatic importing of dictionary representations (e.g. deserialized JSON response) 
- *  of an object to CoreData, using RZVinyl and RZImport.
+ *  of an object to CoreData, using RZVinyl and RZImport. Provides a partial implementation
+ *  of @c RZImportable.
  *
- *  RZImport will only work on the main thread, or inside a @p NSManagedObjectContext rzi_performImport: block.
+ *  @warning Do not override the extended methods or their equivalents from @p RZImportable without reading
+ *           the method documentation. This category provides a crucial implementation of these methods that enables
+ *           automatic Core Data importing.
  */
 @interface NSManagedObject (RZImport) <RZImportable>
 

--- a/Extensions/NSManagedObject+RZImport.h
+++ b/Extensions/NSManagedObject+RZImport.h
@@ -33,12 +33,9 @@
 
 /**
  *  Automatic importing of dictionary representations (e.g. deserialized JSON response) 
- *  of an object to CoreData, using RZVinyl and RZImport. Provides a partial implementation
- *  of @c RZImportable.
+ *  of an object to CoreData, using RZVinyl and RZImport.
  *
- *  @warning Do not override the extended methods or their equivalents from @p RZImportable without reading 
- *           the method documentation. This category provides a crucial implementation of these methods that enables 
- *           automatic Core Data importing.
+ *  RZImport will only work on the main thread, or inside a @p NSManagedObjectContext rzi_performImport: block.
  */
 @interface NSManagedObject (RZImport) <RZImportable>
 
@@ -84,8 +81,8 @@
                                       withMappings:(RZVKeyMap* RZCNullable)mappings;
 
 /**
- *  Creates or updates multiple objects in the provided managed object context using the key/value pairs in the dictionaries 
- *  in the provided array. If an an object with a matching primary key value for a dictionary exists in the context, this method will 
+ *  Creates or updates multiple objects in the provided managed object context using the key/value pairs in the dictionaries
+ *  in the provided array. If an an object with a matching primary key value for a dictionary exists in the context, this method will
  *  update it with the values in the dictionary. If no existing object is found, this method will create/insert a new one and initialize
  *  it with the values in the dictionary. The corresponding imported/updated objects are returned in a new array.
  *
@@ -100,7 +97,7 @@
  *  @return An array matching or newly created objects updated from the key/value pairs in the dictionaries in the array.
  */
 + (RZNonnull NSArray *)rzi_objectsFromArray:(RZVArrayOfStringDict* RZCNonnull)array
-                                   inContext:(NSManagedObjectContext* RZCNonnull)context;
+                                  inContext:(NSManagedObjectContext* RZCNonnull)context;
 
 /**
  *  Creates or updates multiple objects in the provided managed object context using the key/value pairs in the dictionaries
@@ -122,8 +119,8 @@
  *  @return An array matching or newly created objects updated from the key/value pairs in the dictionaries in the array.
  */
 + (NSArray* RZCNonnull)rzi_objectsFromArray:(RZVArrayOfStringDict * RZCNonnull)array
-                                   inContext:(NSManagedObjectContext* RZCNonnull)context
-                                withMappings:(RZVKeyMap* RZCNullable)mappings;
+                                  inContext:(NSManagedObjectContext* RZCNonnull)context
+                               withMappings:(RZVKeyMap* RZCNullable)mappings;
 
 
 /** @name RZImportable Protocol */
@@ -147,6 +144,13 @@
  *          if an object could not be created.
  */
 + (RZNullable id)rzi_existingObjectForDict:(RZVStringDictionary* RZCNonnull)dict inContext:(NSManagedObjectContext* RZCNonnull)context;
+
+@end
+
+/**
+ * The original implementation had versions of the RZImportable methods that provided a context. These implementations are maintained to generate warnings, and then should still function for now.
+ */
+@interface NSManagedObject (RZImportDeprecated)
 
 /**
  * Old Implementations of RZImport methods that passed along the managed object context. The context is not needed for instances of NSManagedObjectContext, since self.managedObjectContext is available.

--- a/Extensions/NSManagedObject+RZImport.h
+++ b/Extensions/NSManagedObject+RZImport.h
@@ -125,38 +125,6 @@
                                    inContext:(NSManagedObjectContext* RZCNonnull)context
                                 withMappings:(RZVKeyMap* RZCNullable)mappings;
 
-/**
- *  Import the values from the provided dictionary into the receiver using the provided context to manage relationships.
- * 
- *  @param dict    The dictionary representing the object to be inserted/updated.
- *  @param context The context in which to find/insert the object. Must not be nil.
- *
- *  @note Calling @p rzi_importValuesFromDict: without the context parameter will use the default context provided by
- *        calling @p +rzv_coreDataStack on the managed object subclass.
- *
- *  @warning This method does not manage object uniqueness as it is an instance method and will act on whatever instance it is called on.
- *
- */
-- (void)rzi_importValuesFromDict:(RZVStringDictionary* RZCNonnull)dict inContext:(NSManagedObjectContext* RZCNonnull)context;
-
-/**
- *  Import the values from the provided dictionary into the receiver using the provided context to manage relationships, with optional extra property mappings.
- *
- *  @param dict    The dictionary representing the object to be inserted/updated.
- *  @param context The context in which to find/insert the object. Must not be nil.
- *  @param mappings An optional dictionary of extra mappings from keys to property names to
- *                  use in the import. These will override/supplement implicit mappings and mappings
- *                  provided by @p RZImportable.
- *
- *  @note Calling @p rzi_importValuesFromDict: without the context parameter will use the default context provided by
- *        calling @p +rzv_coreDataStack on the managed object subclass.
- *
- *  @warning This method does not manage object uniqueness as it is an instance method and will act on whatever instance it is called on.
- */
-- (void)rzi_importValuesFromDict:(RZVStringDictionary* RZCNonnull)dict
-                       inContext:(NSManagedObjectContext* RZCNonnull)context
-                    withMappings:(RZVKeyMap* RZCNullable)mappings;
-
 
 /** @name RZImportable Protocol */
 
@@ -181,25 +149,17 @@
 + (RZNullable id)rzi_existingObjectForDict:(RZVStringDictionary* RZCNonnull)dict inContext:(NSManagedObjectContext* RZCNonnull)context;
 
 /**
- *  Extended implementation of the method from @p RZImportable.
- *  Do not call directly; this is exposed for reasons of documentation only.
- *
- *  If you override this method in an @p NSManagedObject subclass for purposes of validation, you must only prevent 
- *  invalid values from being imported by returning @p NO. For valid import values, you should return the value returned
- *  by this (@p super's) implementation.
- *
- *  @param value   The value being imported for @p key
- *  @param key     The key being imported.
- *  @param context The context in which the import is taking place.
- *
- *  @warning Do not implement the @p RZImportable protocol method @p +rzi_shouldImportValue:forKey: in subclasses.
- *           This method is called by an internal implementation of @p +rzi_shouldImportValue:forKey: which will pass along the correct
- *           context based on a bit of internal state.
- *
- *  @return YES if @p RZImport should perform automatic value import, NO to prevent it from doing so.
+ * Old Implementations of RZImport methods that passed along the managed object context. The context is not needed for instances of NSManagedObjectContext, since self.managedObjectContext is available.
  */
 - (BOOL)rzi_shouldImportValue:(id RZCNonnull)value
                        forKey:(NSString* RZCNonnull)key
-                    inContext:(NSManagedObjectContext* RZCNonnull)context NS_REQUIRES_SUPER;
+                    inContext:(NSManagedObjectContext* RZCNonnull)context NS_REQUIRES_SUPER __attribute__((deprecated("Use -rzi_shouldImportValue:forKey: and self.managedObjectContext")));
+
+- (void)rzi_importValuesFromDict:(RZVStringDictionary* RZCNonnull)dict inContext:(NSManagedObjectContext* RZCNonnull)context __attribute__((deprecated("Use -rzi_importValuesFromDict: and self.managedObjectContext")));
+
+- (void)rzi_importValuesFromDict:(RZVStringDictionary* RZCNonnull)dict
+                       inContext:(NSManagedObjectContext* RZCNonnull)context
+                    withMappings:(RZVKeyMap* RZCNullable)mappings __attribute__((deprecated("Use -rzi_importValuesFromDict:withMappings: and self.managedObjectContext")));
+
 
 @end

--- a/Extensions/NSManagedObject+RZImport.m
+++ b/Extensions/NSManagedObject+RZImport.m
@@ -422,7 +422,7 @@ static NSString * const kRZVinylImportThreadContextKey = @"RZVinylImportThreadCo
 
 - (BOOL)rzi_shouldImportValue:(id)value forKey:(NSString *)key inContext:(NSManagedObjectContext *)context
 {
-    return YES;
+    return [self rzi_shouldImportValue:value forKey:key];
 }
 
 - (void)rzi_importValuesFromDict:(NSDictionary *)dict inContext:(NSManagedObjectContext* RZCNonnull)context

--- a/Extensions/NSManagedObject+RZImport.m
+++ b/Extensions/NSManagedObject+RZImport.m
@@ -173,7 +173,11 @@
 - (void)rzi_importValuesFromDict:(NSDictionary *)dict withMappings:(NSDictionary *)mappings
 {
     mappings = [[self class] rzi_primaryKeyMappingsDictWithMappings:mappings];
+
+    NSManagedObjectContext *importContext = [self.class rzv_currentThreadImportContext];
+    [self.class rzi_setCurrentThreadImportContext:self.managedObjectContext];
     [super rzi_importValuesFromDict:dict withMappings:mappings];
+    [self.class rzi_setCurrentThreadImportContext:importContext];
 }
 
 #pragma mark - RZImportable

--- a/Extensions/NSManagedObject+RZImport.m
+++ b/Extensions/NSManagedObject+RZImport.m
@@ -33,20 +33,10 @@
 #import "NSManagedObject+RZVinylUtils.h"
 #import "NSManagedObject+RZImportableSubclass.h"
 #import "NSManagedObject+RZVinylRecord_private.h"
+#import "NSManagedObjectContext+RZImport.h"
 #import "NSFetchRequest+RZVinylRecord.h"
 #import "RZVinylRelationshipInfo.h"
 #import "RZVinylDefines.h"
-
-#define RZVBeginThreadContext() \
-    BOOL nestedCall = ([[self class] rzv_currentThreadImportContext] != nil); \
-    if ( !nestedCall ) { \
-        [[self class] rzi_setCurrentThreadImportContext:context]; \
-    }
-
-#define RZVEndThreadContext() \
-    if ( !nestedCall ) { \
-        [[self class] rzi_setCurrentThreadImportContext:nil]; \
-    }
 
 //
 // Implementation
@@ -55,70 +45,21 @@
 @implementation NSManagedObject (RZImport)
 
 //!!!: Overridden to support default context
-+ (instancetype)rzi_objectFromDictionary:(NSDictionary *)dict withMappings:(NSDictionary *)mappings
-{
-    // !!!: This is also called internally by the original RZImport methods Need to check if this is part of an ongoing import.
-    //      Otherwise, assert that this is called on the main thread and use the default context.
-    NSManagedObjectContext *context = [self rzv_currentThreadImportContext];
-    if ( context == nil ) {
-        if ( !RZVAssertMainThread() ) {
-            return nil;
-        }
-        context = [[self rzv_validCoreDataStack] mainManagedObjectContext];
-    }
-    return [self rzi_objectFromDictionary:dict inContext:context];
-}
-
-//!!!: Overridden to support default context
 + (NSArray *)rzi_objectsFromArray:(NSArray *)array withMappings:(NSDictionary *)mappings
 {
-    // !!!: This is also called internally by the original RZImport methods Need to check if this is part of an ongoing import.
-    //      Otherwise, assert that this is called on the main thread and use the default context.
-    NSManagedObjectContext *context = [self rzv_currentThreadImportContext];
-    if ( context == nil ) {
-        if ( !RZVAssertMainThread() ) {
-            return nil;
-        }
-        context = [[self rzv_validCoreDataStack] mainManagedObjectContext];
-    }
-    return [self rzi_objectsFromArray:array inContext:context];
+    return [self rzi_optimizedObjectsFromArray:array withMappings:mappings];
 }
 
-+ (instancetype)rzi_objectFromDictionary:(NSDictionary *)dict inContext:(NSManagedObjectContext *)context
++ (instancetype)rzi_objectFromDictionary:(NSDictionary *)dict withMappings:(NSDictionary *)mappings
 {
-    return [self rzi_objectFromDictionary:dict inContext:context withMappings:nil];
+    NSArray *results = [self rzi_optimizedObjectsFromArray:@[dict] withMappings:mappings];
+    return results.lastObject;
 }
 
-+ (instancetype)rzi_objectFromDictionary:(NSDictionary *)dict inContext:(NSManagedObjectContext *)context withMappings:(NSDictionary *)mappings
++ (NSArray *)rzi_optimizedObjectsFromArray:(NSArray *)array withMappings:(NSDictionary *)mappings
 {
-    if ( !RZVParameterAssert(context) ) {
-        return nil;
-    }
-
+    NSManagedObjectContext *context = [NSManagedObjectContext rzi_currentThreadImportContext];
     mappings = [self rzi_primaryKeyMappingsDictWithMappings:mappings];
-    
-    RZVBeginThreadContext();
-    id object = [super rzi_objectFromDictionary:dict withMappings:mappings];
-    RZVEndThreadContext();
-    
-    return object;
-}
-
-+ (NSArray *)rzi_objectsFromArray:(NSArray *)array inContext:(NSManagedObjectContext *)context
-{
-    return [self rzi_objectsFromArray:array inContext:context withMappings:nil];
-}
-
-+ (NSArray *)rzi_objectsFromArray:(NSArray *)array inContext:(NSManagedObjectContext *)context withMappings:(NSDictionary *)mappings
-{
-    if ( !RZVParameterAssert(context) ) {
-        return nil;
-    }
-    
-    mappings = [self rzi_primaryKeyMappingsDictWithMappings:mappings];
-
-    RZVBeginThreadContext();
-
     NSArray *objects = nil;
 
     if ( array.count == 1 ) {
@@ -162,11 +103,9 @@
     }
     else {
         // Default to creating new object instances.
-        objects = [super rzi_objectsFromArray:array withMappings:nil];
+        objects = [super rzi_objectsFromArray:array withMappings:mappings];
     }
-    
-    RZVEndThreadContext();
-    
+
     return objects;
 }
 
@@ -174,27 +113,23 @@
 {
     mappings = [[self class] rzi_primaryKeyMappingsDictWithMappings:mappings];
 
-    NSManagedObjectContext *importContext = [self.class rzv_currentThreadImportContext];
-    [self.class rzi_setCurrentThreadImportContext:self.managedObjectContext];
-    [super rzi_importValuesFromDict:dict withMappings:mappings];
-    [self.class rzi_setCurrentThreadImportContext:importContext];
+    [self.managedObjectContext rzi_performImport:^{
+        [super rzi_importValuesFromDict:dict withMappings:mappings];
+    }];
 }
 
 #pragma mark - RZImportable
 
-+ (id)rzi_existingObjectForDict:(NSDictionary *)dict
++ (instancetype)rzi_existingObjectForDict:(NSDictionary *)dict
 {
-    NSManagedObjectContext *context = [self rzv_currentThreadImportContext];
-    return [self rzi_existingObjectForDict:dict inContext:context];
+    NSManagedObjectContext *context = [NSManagedObjectContext rzi_currentThreadImportContext];
+    id object = [self rzi_existingObjectForDict:dict inContext:context];
+    return object;
 }
 
-+ (id)rzi_existingObjectForDict:(NSDictionary *)dict inContext:(NSManagedObjectContext *)context
++ (id)rzi_existingObjectForDict:(NSDictionary *)dict
+                      inContext:(NSManagedObjectContext *)context
 {
-    if ( !RZVParameterAssert(context) ){
-        RZVLogError(@"This thread does not have an associated managed object context at the moment, and that's a problem.");
-        return nil;
-    }
-    
     if ( [self rzv_shouldAlwaysCreateNewObjectOnImport] ) {
         return [self rzv_newObjectInContext:context];
     }
@@ -236,24 +171,51 @@
     return shouldImport;
 }
 
+#pragma mark - inContext Helpers
+
++ (instancetype)rzi_objectFromDictionary:(NSDictionary *)dict
+                               inContext:(NSManagedObjectContext*)context
+{
+    __block id object = nil;
+    [context rzi_performImport:^{
+        object = [self rzi_objectFromDictionary:dict];
+    }];
+    return object;
+}
+
++ (instancetype)rzi_objectFromDictionary:(NSDictionary *)dict
+                               inContext:(NSManagedObjectContext *)context
+                            withMappings:(NSDictionary *)mappings
+{
+    __block id object = nil;
+    [context rzi_performImport:^{
+        object = [self rzi_objectFromDictionary:dict withMappings:mappings];
+    }];
+    return object;
+}
+
++ (NSArray *)rzi_objectsFromArray:(NSArray *)array
+                        inContext:(NSManagedObjectContext *)context
+{
+    __block NSArray *results = nil;
+    [context rzi_performImport:^{
+        results = [self rzi_objectsFromArray:array];
+    }];
+    return results;
+}
+
++ (NSArray*)rzi_objectsFromArray:(NSArray *)array
+                       inContext:(NSManagedObjectContext *)context
+                    withMappings:(NSDictionary *)mappings
+{
+    __block NSArray *results = nil;
+    [context rzi_performImport:^{
+        results = [self rzi_objectsFromArray:array withMappings:mappings];
+    }];
+    return results;
+}
+
 #pragma mark - Private
-
-static NSString * const kRZVinylImportThreadContextKey = @"RZVinylImportThreadContext";
-
-+ (NSManagedObjectContext *)rzv_currentThreadImportContext
-{
-    return [[[NSThread currentThread] threadDictionary] objectForKey:kRZVinylImportThreadContextKey];
-}
-
-+ (void)rzi_setCurrentThreadImportContext:(NSManagedObjectContext *)context
-{
-    if ( context ) {
-        [[[NSThread currentThread] threadDictionary] setObject:context forKey:kRZVinylImportThreadContextKey];
-    }
-    else {
-        [[[NSThread currentThread] threadDictionary] removeObjectForKey:kRZVinylImportThreadContextKey];
-    }
-}
 
 + (NSDictionary *)rzi_primaryKeyMappingsDictWithMappings:(NSDictionary *)mappings
 {
@@ -274,7 +236,6 @@ static NSString * const kRZVinylImportThreadContextKey = @"RZVinylImportThreadCo
     
     // If no external primary key, then the external key is assumed to match
     return nil;
-
 }
 
 + (RZVinylRelationshipInfo *)rzi_relationshipInfoForKey:(NSString *)key
@@ -296,8 +257,8 @@ static NSString * const kRZVinylImportThreadContextKey = @"RZVinylImportThreadCo
     
     __block id relationshipInfo = [classRelationshipMappings objectForKey:key];
     if ( relationshipInfo == nil && propInfo.propertyName != nil ) {
-        
-        NSManagedObjectModel *model = [[[self rzv_currentThreadImportContext] persistentStoreCoordinator] managedObjectModel];
+        NSManagedObjectContext *context = [NSManagedObjectContext rzi_currentThreadImportContext];
+        NSManagedObjectModel *model = [[context persistentStoreCoordinator] managedObjectModel];
         NSEntityDescription *entity = [[model entitiesByName] objectForKey:[self rzv_entityName]];
         NSRelationshipDescription *relationshipDesc = [[entity relationshipsByName] objectForKey:propInfo.propertyName];
         
@@ -344,7 +305,7 @@ static NSString * const kRZVinylImportThreadContextKey = @"RZVinylImportThreadCo
         return;
     }
     
-    NSManagedObjectContext *context = [[self class] rzv_currentThreadImportContext];
+    NSManagedObjectContext *context = [NSManagedObjectContext rzi_currentThreadImportContext];
     if ( !RZVAssert(context != nil, @"There should be a current thread import context.") ) {
         return;
     }
@@ -363,7 +324,7 @@ static NSString * const kRZVinylImportThreadContextKey = @"RZVinylImportThreadCo
         }
         
         NSArray *rawObjects = value;
-        NSArray *importedObjects = [relationshipInfo.destinationClass rzi_objectsFromArray:rawObjects inContext:context];
+        NSArray *importedObjects = [relationshipInfo.destinationClass rzi_objectsFromArray:rawObjects];
         if ( importedObjects != nil ) {
             if ( relationshipInfo.isOrdered ) {
                 [self setValue:[[NSOrderedSet alloc] initWithArray:importedObjects] forKey:relationshipInfo.sourcePropertyName];
@@ -390,7 +351,7 @@ static NSString * const kRZVinylImportThreadContextKey = @"RZVinylImportThreadCo
             return;
         }
         
-        id importedObject = [relationshipInfo.destinationClass rzi_objectFromDictionary:value inContext:context];
+        id importedObject = [relationshipInfo.destinationClass rzi_objectFromDictionary:value];
         if ( importedObject != nil ) {
             [self setValue:importedObject forKey:relationshipInfo.sourcePropertyName];
         }
@@ -420,12 +381,16 @@ static NSString * const kRZVinylImportThreadContextKey = @"RZVinylImportThreadCo
     });
 }
 
+@end
+
+@implementation NSManagedObject (RZImportDeprecated)
+
 - (BOOL)rzi_shouldImportValue:(id)value forKey:(NSString *)key inContext:(NSManagedObjectContext *)context
 {
     return [self rzi_shouldImportValue:value forKey:key];
 }
 
-- (void)rzi_importValuesFromDict:(NSDictionary *)dict inContext:(NSManagedObjectContext* RZCNonnull)context
+- (void)rzi_importValuesFromDict:(NSDictionary *)dict inContext:(NSManagedObjectContext *)context
 {
     [self rzi_importValuesFromDict:dict];
 }
@@ -436,6 +401,5 @@ static NSString * const kRZVinylImportThreadContextKey = @"RZVinylImportThreadCo
 {
     [self rzi_importValuesFromDict:dict withMappings:mappings];
 }
-
 
 @end

--- a/Extensions/NSManagedObject+RZImportableSubclass.h
+++ b/Extensions/NSManagedObject+RZImportableSubclass.h
@@ -9,7 +9,7 @@
 //
 //  Permission is hereby granted, free of charge, to any person obtaining
 //  a copy of this software and associated documentation files (the
-//                                                                "Software"), to deal in the Software without restriction, including
+//  "Software"), to deal in the Software without restriction, including
 //  without limitation the rights to use, copy, modify, merge, publish,
 //  distribute, sublicense, and/or sell copies of the Software, and to
 //  permit persons to whom the Software is furnished to do so, subject to

--- a/Extensions/NSManagedObject+RZImportableSubclass.m
+++ b/Extensions/NSManagedObject+RZImportableSubclass.m
@@ -9,7 +9,7 @@
 //
 //  Permission is hereby granted, free of charge, to any person obtaining
 //  a copy of this software and associated documentation files (the
-//                                                                "Software"), to deal in the Software without restriction, including
+//  "Software"), to deal in the Software without restriction, including
 //  without limitation the rights to use, copy, modify, merge, publish,
 //  distribute, sublicense, and/or sell copies of the Software, and to
 //  permit persons to whom the Software is furnished to do so, subject to

--- a/Extensions/NSManagedObjectContext+RZImport.h
+++ b/Extensions/NSManagedObjectContext+RZImport.h
@@ -30,8 +30,17 @@
 
 @interface NSManagedObjectContext (RZImport)
 
+/**
+ *  Specify that this managed object context should be used for all subsequent
+ *  RZImport operations. This enables RZImport to work with NSObjects containing
+ *  NSManagedObjects.
+ */
 - (void)rzi_performImport:(void(^)(void))importBlock;
 
+/**
+ *  The managed object context that is being imported to. This is set internally
+ *  and by the `rzi_performImport:` method.
+ */
 + (NSManagedObjectContext *)rzi_currentThreadImportContext;
 
 @end

--- a/Extensions/NSManagedObjectContext+RZImport.h
+++ b/Extensions/NSManagedObjectContext+RZImport.h
@@ -1,15 +1,15 @@
 //
-//  RZVinyl.h
+//  NSManagedObjectContext+RZImport.h
 //  RZVinyl
 //
-//  Created by Nick Donaldson on 6/4/14.
+//  Created by Brian King on 1/12/16.
 //
 //  Copyright 2014 Raizlabs and other contributors
 //  http://raizlabs.com/
 //
 //  Permission is hereby granted, free of charge, to any person obtaining
 //  a copy of this software and associated documentation files (the
-//                                                                "Software"), to deal in the Software without restriction, including
+//  Software"), to deal in the Software without restriction, including
 //  without limitation the rights to use, copy, modify, merge, publish,
 //  distribute, sublicense, and/or sell copies of the Software, and to
 //  permit persons to whom the Software is furnished to do so, subject to
@@ -26,32 +26,12 @@
 //  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 //  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#import "RZCoreDataStack.h"
-#import "NSManagedObject+RZVinylRecord.h"
-#import "NSManagedObject+RZVinylUtils.h"
-#import "NSFetchRequest+RZVinylRecord.h"
-#import "NSFetchedResultsController+RZVinylRecord.h"
-#import "NSManagedObjectContext+RZVinylSave.h"
+@import CoreData;
 
-#if (RZV_IMPORT_AVAILABLE)
-    #import "NSManagedObject+RZImport.h"
-    #import "NSManagedObjectContext+RZImport.h"
-    #import "NSManagedObject+RZImportableSubclass.h"
-#endif
+@interface NSManagedObjectContext (RZImport)
 
+- (void)rzi_performImport:(void(^)(void))importBlock;
 
-//
-// Public Macros
-//
++ (NSManagedObjectContext *)rzi_currentThreadImportContext;
 
-/**
- *  Shorthand for creating an NSPredicate
- */
-#define RZVPred(format, ...) \
-    [NSPredicate predicateWithFormat:format, ##__VA_ARGS__]
-
-/**
- *  Shorthand for creating an NSSortDescriptor
- */
-#define RZVKeySort(keyPath, isAscending) \
-    [NSSortDescriptor sortDescriptorWithKey:keyPath ascending:isAscending]
+@end

--- a/Extensions/NSManagedObjectContext+RZImport.m
+++ b/Extensions/NSManagedObjectContext+RZImport.m
@@ -1,0 +1,76 @@
+//
+//  NSManagedObjectContext+RZImport.m
+//  RZVinyl
+//
+//  Created by Brian King on 1/12/16.
+//
+//  Copyright 2014 Raizlabs and other contributors
+//  http://raizlabs.com/
+//
+//  Permission is hereby granted, free of charge, to any person obtaining
+//  a copy of this software and associated documentation files (the
+//  Software"), to deal in the Software without restriction, including
+//  without limitation the rights to use, copy, modify, merge, publish,
+//  distribute, sublicense, and/or sell copies of the Software, and to
+//  permit persons to whom the Software is furnished to do so, subject to
+//  the following conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+//  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+//  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+//  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "NSManagedObjectContext+RZImport.h"
+#import "RZCoreDataStack.h"
+
+@implementation NSThread (RZImport)
+
+static NSString * const kRZVinylImportThreadContextKey = @"RZVinylImportThreadContext";
+
+- (NSManagedObjectContext *)rzi_currentImportContext
+{
+    NSManagedObjectContext *context = [[self threadDictionary] objectForKey:kRZVinylImportThreadContextKey];
+    return context;
+}
+
+- (void)rzi_setCurrentImportContext:(NSManagedObjectContext *)context
+{
+    if ( context ) {
+        [[self threadDictionary] setObject:context forKey:kRZVinylImportThreadContextKey];
+    }
+    else {
+        [[self threadDictionary] removeObjectForKey:kRZVinylImportThreadContextKey];
+    }
+}
+
+@end
+
+@implementation NSManagedObjectContext (RZImport)
+
+- (void)rzi_performImport:(void(^)(void))importBlock
+{
+    NSParameterAssert(importBlock);
+    NSThread *thread = [NSThread currentThread];
+    NSManagedObjectContext *initialImportContext = [thread rzi_currentImportContext];
+    [thread rzi_setCurrentImportContext:self];
+    [self performBlockAndWait:importBlock];
+    [thread rzi_setCurrentImportContext:initialImportContext];
+}
+
++ (NSManagedObjectContext *)rzi_currentThreadImportContext
+{
+    NSManagedObjectContext *context = [[NSThread currentThread] rzi_currentImportContext];
+    if ( context == nil && [NSThread currentThread] == [NSThread mainThread] ) {
+        context = [[RZCoreDataStack defaultStack] mainManagedObjectContext];
+    }
+    NSAssert(context != nil, @"RZImport is attempting to perform an import with out an import context. Make sure that you use RZImport from inside -[NSManagedObjectContext rzi_performImport].");
+    return context;
+}
+
+@end


### PR DESCRIPTION
Since we're changing API's, this PR removes a simple difference between NSManagedObject RZImport and NSObject RZImport. It drops instance methods that have a context supplied. This is not needed because `self.managedObjectContext` is always present (with the exception of a few weird delete cases).

This is the first step in removing the differences between RZImport for NSManagedObject and NSObject. I don't see many reasons to object to this change, but the other removals will be more opinionated, so I've separated them into another PR.
