### PR TITLE
Remove context usage in RZImportable

### DIFF
--- a/Example/RZVinylDemo/Services/RZPersonLoader.m
+++ b/Example/RZVinylDemo/Services/RZPersonLoader.m
@@ -34,17 +34,19 @@ static NSString* kRZPersonDataFileName = @"person_data.json";
        
         NSRange importRange = NSMakeRange(self.offset, MIN(batchSize, self.rawPeople.count - self.offset) );
         NSArray *peopleInRange = [self.rawPeople subarrayWithRange:importRange];
-        
-        // Create an array of RZPerson objects imported from the deserialized JSON
-        NSArray *importedPeople = [RZPerson rzi_objectsFromArray:peopleInRange inContext:context];
-        
-        // Set a sort index for each person that is imported
-        [importedPeople enumerateObjectsUsingBlock:^(RZPerson *person, NSUInteger idx, BOOL *stop) {
-            person.sortIndex = @(importRange.location + idx);
+
+        [context rzi_performImport:^{
+            // Create an array of RZPerson objects imported from the deserialized JSON
+            NSArray *importedPeople = [RZPerson rzi_objectsFromArray:peopleInRange];
+
+            // Set a sort index for each person that is imported
+            [importedPeople enumerateObjectsUsingBlock:^(RZPerson *person, NSUInteger idx, BOOL *stop) {
+                person.sortIndex = @(importRange.location + idx);
+            }];
+
+            self.offset += batchSize;
         }];
-        
-        self.offset += batchSize;
-        
+
     } completion:completion];
 }
 

--- a/Example/RZVinylTests/RZVinylImportTests.m
+++ b/Example/RZVinylTests/RZVinylImportTests.m
@@ -66,8 +66,11 @@
     
     __block BOOL finished = NO;
     [self.stack performBlockUsingBackgroundContext:^(NSManagedObjectContext *context) {
-        
-        Artist *dusky = [Artist rzi_objectFromDictionary:duskyRaw inContext:context];
+
+        __block Artist *dusky = nil;
+        [context rzi_performImport:^{
+            dusky = [Artist rzi_objectFromDictionary:duskyRaw];
+        }];
         XCTAssertNotNil(dusky, @"Failed to import from dict");
         XCTAssertEqualObjects(dusky.managedObjectContext, context, @"Wrong context");
         XCTAssertEqualObjects(dusky.name, duskyRaw[@"name"], @"Name import failed");
@@ -119,7 +122,10 @@
     __block BOOL finished = NO;
     [self.stack performBlockUsingBackgroundContext:^(NSManagedObjectContext *context) {
         
-        NSArray *artists = [Artist rzi_objectsFromArray:self.rawArtists inContext:context];
+        __block NSArray *artists = nil;
+        [context rzi_performImport:^{
+            artists = [Artist rzi_objectsFromArray:self.rawArtists];
+        }];
         XCTAssertNotNil(artists, @"Failed to import array");
         XCTAssertEqual(artists.count, 3, @"Wrong number of artists");
         XCTAssertEqualObjects(context, [artists[0] managedObjectContext], @"Wrong context");
@@ -260,7 +266,9 @@
     NSTimeInterval start = [NSDate timeIntervalSinceReferenceDate];
     __block NSTimeInterval finish = 0;
     [[RZCoreDataStack defaultStack] performBlockUsingBackgroundContext:^(NSManagedObjectContext *context) {
-        [Artist rzi_objectsFromArray:artistArray inContext:context];
+        [context rzi_performImport:^{
+            [Artist rzi_objectsFromArray:artistArray];
+        }];
     } completion:^(NSError *err) {
         finish = [NSDate timeIntervalSinceReferenceDate];
         [saveExpectation fulfill];

--- a/Extensions/NSManagedObject+RZImport.h
+++ b/Extensions/NSManagedObject+RZImport.h
@@ -39,6 +39,112 @@
  */
 @interface NSManagedObject (RZImport) <RZImportable>
 
+/**
+ *  Creates or updates an object in the provided managed object context using the key/value pairs in the provided dictionary.
+ *  If an an object with a matching primary key value exists in the context, this method will update it with the values in
+ *  the dictionary and return the result. If no existing object is found, this method will create/insert a new one and initialize
+ *  it with the values in the dictionary.
+ *
+ *  @param dict    The dictionary representing the object to be inserted/updated.
+ *  @param context The context in which to find/insert the object. Must not be nil.
+ *
+ *  @note Calling @p rzi_objectFromDictionary: without the context parameter will use the default context provided by
+ *        calling @p +rzv_coreDataStack on the managed object subclass.
+ *
+ *  @note This method does not save the context or the core data stack.
+ *
+ *  @return A matching or newly created object updated from the key/value pairs in the dictionary.
+ */
++ (RZNonnull instancetype)rzi_objectFromDictionary:(RZVStringDictionary* RZCNonnull)dict inContext:(NSManagedObjectContext* RZCNonnull)context;
+
+/**
+ *  Creates or updates an object in the provided managed object context using the key/value pairs in the provided dictionary.
+ *  If an an object with a matching primary key value exists in the context, this method will update it with the values in
+ *  the dictionary and return the result. If no existing object is found, this method will create/insert a new one and initialize
+ *  it with the values in the dictionary.
+ *
+ *  @param dict    The dictionary representing the object to be inserted/updated.
+ *  @param context The context in which to find/insert the object. Must not be nil.
+ *  @param mappings An optional dictionary of extra mappings from keys to property names to
+ *                  use in the import. These will override/supplement implicit mappings and mappings
+ *                  provided by @p RZImportable.
+ *
+ *  @note Calling @p rzi_objectFromDictionary: without the context parameter will use the default context provided by
+ *        calling @p +rzv_coreDataStack on the managed object subclass.
+ *
+ *  @note This method does not save the context or the core data stack.
+ *
+ *  @return A matching or newly created object updated from the key/value pairs in the dictionary.
+ */
++ (RZNonnull instancetype)rzi_objectFromDictionary:(RZVStringDictionary* RZCNonnull)dict
+                                         inContext:(NSManagedObjectContext* RZCNonnull)context
+                                      withMappings:(RZVKeyMap* RZCNullable)mappings;
+
+/**
+ *  Creates or updates multiple objects in the provided managed object context using the key/value pairs in the dictionaries
+ *  in the provided array. If an an object with a matching primary key value for a dictionary exists in the context, this method will
+ *  update it with the values in the dictionary. If no existing object is found, this method will create/insert a new one and initialize
+ *  it with the values in the dictionary. The corresponding imported/updated objects are returned in a new array.
+ *
+ *  @param array   An array of @p NSDictionary instances representing objects to be inserted/updated.
+ *  @param context The context in which to find/insert the object. Must not be nil.
+ *
+ *  @note Calling @p rzi_objectsFromArray: without the context parameter will use the default context provided by
+ *        calling @p +rzv_coreDataStack on the managed object subclass.
+ *
+ *  @note This method does not save the context or the core data stack.
+ *
+ *  @return An array matching or newly created objects updated from the key/value pairs in the dictionaries in the array.
+ */
++ (RZNonnull NSArray *)rzi_objectsFromArray:(RZVArrayOfStringDict* RZCNonnull)array
+                                  inContext:(NSManagedObjectContext* RZCNonnull)context;
+
+/**
+ *  Creates or updates multiple objects in the provided managed object context using the key/value pairs in the dictionaries
+ *  in the provided array. If an an object with a matching primary key value for a dictionary exists in the context, this method will
+ *  update it with the values in the dictionary. If no existing object is found, this method will create/insert a new one and initialize
+ *  it with the values in the dictionary. The corresponding imported/updated objects are returned in a new array.
+ *
+ *  @param array   An array of @p NSDictionary instances representing objects to be inserted/updated.
+ *  @param context The context in which to find/insert the object. Must not be nil.
+ *  @param mappings An optional dictionary of extra mappings from keys to property names to
+ *                  use in the import. These will override/supplement implicit mappings and mappings
+ *                  provided by @p RZImportable.
+ *
+ *  @note Calling @p rzi_objectsFromArray: without the context parameter will use the default context provided by
+ *        calling @p +rzv_coreDataStack on the managed object subclass.
+ *
+ *  @note This method does not save the context or the core data stack.
+ *
+ *  @return An array matching or newly created objects updated from the key/value pairs in the dictionaries in the array.
+ */
++ (NSArray* RZCNonnull)rzi_objectsFromArray:(RZVArrayOfStringDict * RZCNonnull)array
+                                  inContext:(NSManagedObjectContext* RZCNonnull)context
+                               withMappings:(RZVKeyMap* RZCNullable)mappings;
+
+
+/** @name RZImportable Protocol */
+
+
+/**
+ *  Extended implementation of the method from @p RZImportable.
+ *  Do not call directly; this is exposed for reasons of documentation only.
+ *
+ *  If you override this method in an @p NSManagedObject subclass, it must always return a valid instance
+ *  of the receiver's class, whether previously existing or newly inserted into the supplied context.
+ *
+ *  @param dict The dictionary representing an instance of the receiver's class.
+ *  @param context The managed object context in which to find/insert the object.
+ *
+ *  @warning Do not implement the @p RZImportable protocol method @p +rzi_existingObjectForDict: in subclasses.
+ *           This method is called by an internal implementation of @p +rzi_existingObjectForDict: which will pass along the correct
+ *           context based on a bit of internal state.
+ *
+ *  @return A valid NSManagedObject initialized with the provided dictionary, or nil
+ *          if an object could not be created.
+ */
++ (RZNullable id)rzi_existingObjectForDict:(RZVStringDictionary* RZCNonnull)dict inContext:(NSManagedObjectContext* RZCNonnull)context;
+
 @end
 
 /**
@@ -46,40 +152,18 @@
  */
 @interface NSManagedObject (RZImportDeprecated)
 
-+ (RZNonnull instancetype)rzi_objectFromDictionary:(RZVStringDictionary* RZCNonnull)dict
-                                         inContext:(NSManagedObjectContext* RZCNonnull)context
-__attribute__((deprecated("Use -rzi_objectFromDictionary: from inside -[NSManagedObjectContext rzi_performBlock:]")));
-
-+ (RZNonnull instancetype)rzi_objectFromDictionary:(RZVStringDictionary* RZCNonnull)dict
-                                         inContext:(NSManagedObjectContext* RZCNonnull)context
-                                      withMappings:(RZVKeyMap* RZCNullable)mappings
-__attribute__((deprecated("Use -rzi_objectFromDictionary:withMappings: from inside -[NSManagedObjectContext rzi_performBlock:]")));
-
-+ (RZNonnull NSArray *)rzi_objectsFromArray:(RZVArrayOfStringDict* RZCNonnull)array
-                                  inContext:(NSManagedObjectContext* RZCNonnull)context
-__attribute__((deprecated("Use -rzi_objectsFromArray: from inside -[NSManagedObjectContext rzi_performBlock:]")));
-
-+ (NSArray* RZCNonnull)rzi_objectsFromArray:(RZVArrayOfStringDict * RZCNonnull)array
-                                  inContext:(NSManagedObjectContext* RZCNonnull)context
-                               withMappings:(RZVKeyMap* RZCNullable)mappings
-__attribute__((deprecated("Use -rzi_objectsFromArray:withMappings: from inside -[NSManagedObjectContext rzi_performBlock:]")));
-
-+ (RZNullable id)rzi_existingObjectForDict:(RZVStringDictionary* RZCNonnull)dict
-                                 inContext:(NSManagedObjectContext* RZCNonnull)context
-__attribute__((deprecated("Use -rzi_objectsFromArray:withMappings: from inside -[NSManagedObjectContext rzi_performBlock:]")));
-
+/**
+ * Old Implementations of RZImport methods that passed along the managed object context. The context is not needed for instances of NSManagedObjectContext, since self.managedObjectContext is available.
+ */
 - (BOOL)rzi_shouldImportValue:(id RZCNonnull)value
                        forKey:(NSString* RZCNonnull)key
-                    inContext:(NSManagedObjectContext* RZCNonnull)context
-__attribute__((deprecated("Use -rzi_shouldImportValue:forKey: and self.managedObjectContext")));
+                    inContext:(NSManagedObjectContext* RZCNonnull)context NS_REQUIRES_SUPER __attribute__((deprecated("Use -rzi_shouldImportValue:forKey: and self.managedObjectContext")));
 
-- (void)rzi_importValuesFromDict:(RZVStringDictionary* RZCNonnull)dict inContext:(NSManagedObjectContext* RZCNonnull)context
-__attribute__((deprecated("Use -rzi_importValuesFromDict: and self.managedObjectContext")));
+- (void)rzi_importValuesFromDict:(RZVStringDictionary* RZCNonnull)dict inContext:(NSManagedObjectContext* RZCNonnull)context __attribute__((deprecated("Use -rzi_importValuesFromDict: and self.managedObjectContext")));
 
 - (void)rzi_importValuesFromDict:(RZVStringDictionary* RZCNonnull)dict
                        inContext:(NSManagedObjectContext* RZCNonnull)context
-                    withMappings:(RZVKeyMap* RZCNullable)mappings
-__attribute__((deprecated("Use -rzi_importValuesFromDict:withMappings: and self.managedObjectContext")));
+                    withMappings:(RZVKeyMap* RZCNullable)mappings __attribute__((deprecated("Use -rzi_importValuesFromDict:withMappings: and self.managedObjectContext")));
 
 
 @end

--- a/Extensions/NSManagedObject+RZImport.h
+++ b/Extensions/NSManagedObject+RZImport.h
@@ -33,133 +33,53 @@
 
 /**
  *  Automatic importing of dictionary representations (e.g. deserialized JSON response) 
- *  of an object to CoreData, using RZVinyl and RZImport. Provides a partial implementation
- *  of @c RZImportable.
+ *  of an object to CoreData, using RZVinyl and RZImport.
  *
- *  @warning Do not override the extended methods or their equivalents from @p RZImportable without reading 
- *           the method documentation. This category provides a crucial implementation of these methods that enables 
- *           automatic Core Data importing.
+ *  RZImport will only work on the main thread, or inside a @p NSManagedObjectContext rzi_performImport: block.
  */
 @interface NSManagedObject (RZImport) <RZImportable>
 
-/**
- *  Creates or updates an object in the provided managed object context using the key/value pairs in the provided dictionary.
- *  If an an object with a matching primary key value exists in the context, this method will update it with the values in
- *  the dictionary and return the result. If no existing object is found, this method will create/insert a new one and initialize
- *  it with the values in the dictionary.
- *
- *  @param dict    The dictionary representing the object to be inserted/updated.
- *  @param context The context in which to find/insert the object. Must not be nil.
- *
- *  @note Calling @p rzi_objectFromDictionary: without the context parameter will use the default context provided by
- *        calling @p +rzv_coreDataStack on the managed object subclass.
- *
- *  @note This method does not save the context or the core data stack.
- *
- *  @return A matching or newly created object updated from the key/value pairs in the dictionary.
- */
-+ (RZNonnull instancetype)rzi_objectFromDictionary:(RZVStringDictionary* RZCNonnull)dict inContext:(NSManagedObjectContext* RZCNonnull)context;
+@end
 
 /**
- *  Creates or updates an object in the provided managed object context using the key/value pairs in the provided dictionary.
- *  If an an object with a matching primary key value exists in the context, this method will update it with the values in
- *  the dictionary and return the result. If no existing object is found, this method will create/insert a new one and initialize
- *  it with the values in the dictionary.
- *
- *  @param dict    The dictionary representing the object to be inserted/updated.
- *  @param context The context in which to find/insert the object. Must not be nil.
- *  @param mappings An optional dictionary of extra mappings from keys to property names to
- *                  use in the import. These will override/supplement implicit mappings and mappings
- *                  provided by @p RZImportable.
- *
- *  @note Calling @p rzi_objectFromDictionary: without the context parameter will use the default context provided by
- *        calling @p +rzv_coreDataStack on the managed object subclass.
- *
- *  @note This method does not save the context or the core data stack.
- *
- *  @return A matching or newly created object updated from the key/value pairs in the dictionary.
+ * The original implementation had versions of the RZImportable methods that provided a context. These implementations are maintained to generate warnings, and then should still function for now.
  */
+@interface NSManagedObject (RZImportDeprecated)
+
 + (RZNonnull instancetype)rzi_objectFromDictionary:(RZVStringDictionary* RZCNonnull)dict
                                          inContext:(NSManagedObjectContext* RZCNonnull)context
-                                      withMappings:(RZVKeyMap* RZCNullable)mappings;
+__attribute__((deprecated("Use -rzi_objectFromDictionary: from inside -[NSManagedObjectContext rzi_performBlock:]")));
 
-/**
- *  Creates or updates multiple objects in the provided managed object context using the key/value pairs in the dictionaries 
- *  in the provided array. If an an object with a matching primary key value for a dictionary exists in the context, this method will 
- *  update it with the values in the dictionary. If no existing object is found, this method will create/insert a new one and initialize
- *  it with the values in the dictionary. The corresponding imported/updated objects are returned in a new array.
- *
- *  @param array   An array of @p NSDictionary instances representing objects to be inserted/updated.
- *  @param context The context in which to find/insert the object. Must not be nil.
- *
- *  @note Calling @p rzi_objectsFromArray: without the context parameter will use the default context provided by
- *        calling @p +rzv_coreDataStack on the managed object subclass.
- *
- *  @note This method does not save the context or the core data stack.
- *
- *  @return An array matching or newly created objects updated from the key/value pairs in the dictionaries in the array.
- */
++ (RZNonnull instancetype)rzi_objectFromDictionary:(RZVStringDictionary* RZCNonnull)dict
+                                         inContext:(NSManagedObjectContext* RZCNonnull)context
+                                      withMappings:(RZVKeyMap* RZCNullable)mappings
+__attribute__((deprecated("Use -rzi_objectFromDictionary:withMappings: from inside -[NSManagedObjectContext rzi_performBlock:]")));
+
 + (RZNonnull NSArray *)rzi_objectsFromArray:(RZVArrayOfStringDict* RZCNonnull)array
-                                   inContext:(NSManagedObjectContext* RZCNonnull)context;
+                                  inContext:(NSManagedObjectContext* RZCNonnull)context
+__attribute__((deprecated("Use -rzi_objectsFromArray: from inside -[NSManagedObjectContext rzi_performBlock:]")));
 
-/**
- *  Creates or updates multiple objects in the provided managed object context using the key/value pairs in the dictionaries
- *  in the provided array. If an an object with a matching primary key value for a dictionary exists in the context, this method will
- *  update it with the values in the dictionary. If no existing object is found, this method will create/insert a new one and initialize
- *  it with the values in the dictionary. The corresponding imported/updated objects are returned in a new array.
- *
- *  @param array   An array of @p NSDictionary instances representing objects to be inserted/updated.
- *  @param context The context in which to find/insert the object. Must not be nil.
- *  @param mappings An optional dictionary of extra mappings from keys to property names to
- *                  use in the import. These will override/supplement implicit mappings and mappings
- *                  provided by @p RZImportable.
- *
- *  @note Calling @p rzi_objectsFromArray: without the context parameter will use the default context provided by
- *        calling @p +rzv_coreDataStack on the managed object subclass.
- *
- *  @note This method does not save the context or the core data stack.
- *
- *  @return An array matching or newly created objects updated from the key/value pairs in the dictionaries in the array.
- */
 + (NSArray* RZCNonnull)rzi_objectsFromArray:(RZVArrayOfStringDict * RZCNonnull)array
-                                   inContext:(NSManagedObjectContext* RZCNonnull)context
-                                withMappings:(RZVKeyMap* RZCNullable)mappings;
+                                  inContext:(NSManagedObjectContext* RZCNonnull)context
+                               withMappings:(RZVKeyMap* RZCNullable)mappings
+__attribute__((deprecated("Use -rzi_objectsFromArray:withMappings: from inside -[NSManagedObjectContext rzi_performBlock:]")));
 
++ (RZNullable id)rzi_existingObjectForDict:(RZVStringDictionary* RZCNonnull)dict
+                                 inContext:(NSManagedObjectContext* RZCNonnull)context
+__attribute__((deprecated("Use -rzi_objectsFromArray:withMappings: from inside -[NSManagedObjectContext rzi_performBlock:]")));
 
-/** @name RZImportable Protocol */
-
-
-/**
- *  Extended implementation of the method from @p RZImportable.
- *  Do not call directly; this is exposed for reasons of documentation only.
- *
- *  If you override this method in an @p NSManagedObject subclass, it must always return a valid instance
- *  of the receiver's class, whether previously existing or newly inserted into the supplied context.
- *
- *  @param dict The dictionary representing an instance of the receiver's class.
- *  @param context The managed object context in which to find/insert the object.
- *
- *  @warning Do not implement the @p RZImportable protocol method @p +rzi_existingObjectForDict: in subclasses.
- *           This method is called by an internal implementation of @p +rzi_existingObjectForDict: which will pass along the correct
- *           context based on a bit of internal state.
- *
- *  @return A valid NSManagedObject initialized with the provided dictionary, or nil
- *          if an object could not be created.
- */
-+ (RZNullable id)rzi_existingObjectForDict:(RZVStringDictionary* RZCNonnull)dict inContext:(NSManagedObjectContext* RZCNonnull)context;
-
-/**
- * Old Implementations of RZImport methods that passed along the managed object context. The context is not needed for instances of NSManagedObjectContext, since self.managedObjectContext is available.
- */
 - (BOOL)rzi_shouldImportValue:(id RZCNonnull)value
                        forKey:(NSString* RZCNonnull)key
-                    inContext:(NSManagedObjectContext* RZCNonnull)context NS_REQUIRES_SUPER __attribute__((deprecated("Use -rzi_shouldImportValue:forKey: and self.managedObjectContext")));
+                    inContext:(NSManagedObjectContext* RZCNonnull)context
+__attribute__((deprecated("Use -rzi_shouldImportValue:forKey: and self.managedObjectContext")));
 
-- (void)rzi_importValuesFromDict:(RZVStringDictionary* RZCNonnull)dict inContext:(NSManagedObjectContext* RZCNonnull)context __attribute__((deprecated("Use -rzi_importValuesFromDict: and self.managedObjectContext")));
+- (void)rzi_importValuesFromDict:(RZVStringDictionary* RZCNonnull)dict inContext:(NSManagedObjectContext* RZCNonnull)context
+__attribute__((deprecated("Use -rzi_importValuesFromDict: and self.managedObjectContext")));
 
 - (void)rzi_importValuesFromDict:(RZVStringDictionary* RZCNonnull)dict
                        inContext:(NSManagedObjectContext* RZCNonnull)context
-                    withMappings:(RZVKeyMap* RZCNullable)mappings __attribute__((deprecated("Use -rzi_importValuesFromDict:withMappings: and self.managedObjectContext")));
+                    withMappings:(RZVKeyMap* RZCNullable)mappings
+__attribute__((deprecated("Use -rzi_importValuesFromDict:withMappings: and self.managedObjectContext")));
 
 
 @end

--- a/Extensions/NSManagedObject+RZImport.m
+++ b/Extensions/NSManagedObject+RZImport.m
@@ -390,7 +390,7 @@
     return [self rzi_shouldImportValue:value forKey:key];
 }
 
-- (void)rzi_importValuesFromDict:(NSDictionary *)dict inContext:(NSManagedObjectContext* RZCNonnull)context
+- (void)rzi_importValuesFromDict:(NSDictionary *)dict inContext:(NSManagedObjectContext *)context
 {
     [self rzi_importValuesFromDict:dict];
 }

--- a/Extensions/NSManagedObjectContext+RZImport.h
+++ b/Extensions/NSManagedObjectContext+RZImport.h
@@ -1,15 +1,15 @@
 //
-//  RZVinyl.h
+//  NSManagedObjectContext+RZImport.h
 //  RZVinyl
 //
-//  Created by Nick Donaldson on 6/4/14.
+//  Created by Brian King on 1/12/16.
 //
 //  Copyright 2014 Raizlabs and other contributors
 //  http://raizlabs.com/
 //
 //  Permission is hereby granted, free of charge, to any person obtaining
 //  a copy of this software and associated documentation files (the
-//                                                                "Software"), to deal in the Software without restriction, including
+//  Software"), to deal in the Software without restriction, including
 //  without limitation the rights to use, copy, modify, merge, publish,
 //  distribute, sublicense, and/or sell copies of the Software, and to
 //  permit persons to whom the Software is furnished to do so, subject to
@@ -26,32 +26,12 @@
 //  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 //  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#import "RZCoreDataStack.h"
-#import "NSManagedObject+RZVinylRecord.h"
-#import "NSManagedObject+RZVinylUtils.h"
-#import "NSFetchRequest+RZVinylRecord.h"
-#import "NSFetchedResultsController+RZVinylRecord.h"
-#import "NSManagedObjectContext+RZVinylSave.h"
+#import <CoreData/CoreData.h>
 
-#if (RZV_IMPORT_AVAILABLE)
-    #import "NSManagedObject+RZImport.h"
-    #import "NSManagedObjectContext+RZImport.h"
-    #import "NSManagedObject+RZImportableSubclass.h"
-#endif
+@interface NSManagedObjectContext (RZImport)
 
+- (void)rzi_performImport:(void(^)(void))importBlock;
 
-//
-// Public Macros
-//
++ (NSManagedObjectContext *)rzi_currentThreadImportContext;
 
-/**
- *  Shorthand for creating an NSPredicate
- */
-#define RZVPred(format, ...) \
-    [NSPredicate predicateWithFormat:format, ##__VA_ARGS__]
-
-/**
- *  Shorthand for creating an NSSortDescriptor
- */
-#define RZVKeySort(keyPath, isAscending) \
-    [NSSortDescriptor sortDescriptorWithKey:keyPath ascending:isAscending]
+@end

--- a/Extensions/NSManagedObjectContext+RZImport.h
+++ b/Extensions/NSManagedObjectContext+RZImport.h
@@ -26,7 +26,7 @@
 //  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 //  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#import <CoreData/CoreData.h>
+@import CoreData;
 
 @interface NSManagedObjectContext (RZImport)
 

--- a/Extensions/NSManagedObjectContext+RZImport.m
+++ b/Extensions/NSManagedObjectContext+RZImport.m
@@ -1,0 +1,76 @@
+//
+//  NSManagedObjectContext+RZImport.m
+//  RZVinyl
+//
+//  Created by Brian King on 1/12/16.
+//
+//  Copyright 2014 Raizlabs and other contributors
+//  http://raizlabs.com/
+//
+//  Permission is hereby granted, free of charge, to any person obtaining
+//  a copy of this software and associated documentation files (the
+//  Software"), to deal in the Software without restriction, including
+//  without limitation the rights to use, copy, modify, merge, publish,
+//  distribute, sublicense, and/or sell copies of the Software, and to
+//  permit persons to whom the Software is furnished to do so, subject to
+//  the following conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+//  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+//  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+//  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "NSManagedObjectContext+RZImport.h"
+#import "RZCoreDataStack.h"
+
+@implementation NSThread (RZImport)
+
+static NSString * const kRZVinylImportThreadContextKey = @"RZVinylImportThreadContext";
+
+- (NSManagedObjectContext *)rzi_currentImportContext
+{
+    NSManagedObjectContext *context = [[self threadDictionary] objectForKey:kRZVinylImportThreadContextKey];
+    return context;
+}
+
+- (void)rzi_setCurrentImportContext:(NSManagedObjectContext *)context
+{
+    if ( context ) {
+        [[self threadDictionary] setObject:context forKey:kRZVinylImportThreadContextKey];
+    }
+    else {
+        [[self threadDictionary] removeObjectForKey:kRZVinylImportThreadContextKey];
+    }
+}
+
+@end
+
+@implementation NSManagedObjectContext (RZImport)
+
+- (void)rzi_performImport:(void(^)(void))importBlock
+{
+    NSParameterAssert(importBlock);
+    NSThread *thread = [NSThread currentThread];
+    NSManagedObjectContext *initialImportContext = [thread rzi_currentImportContext];
+    [thread rzi_setCurrentImportContext:self];
+    [self performBlockAndWait:importBlock];
+    [thread rzi_setCurrentImportContext:initialImportContext];
+}
+
++ (NSManagedObjectContext *)rzi_currentThreadImportContext
+{
+    NSManagedObjectContext *context = [[NSThread currentThread] rzi_currentImportContext];
+    if ( context == nil && [NSThread currentThread] == [NSThread mainThread] ) {
+        context = [[RZCoreDataStack defaultStack] mainManagedObjectContext];
+    }
+    NSAssert(context != nil, @"RZImport is attempting to perform an import with out an import context. Make sure that you use RZImport from inside -[NSManagedObjectContext rzi_performImport].");
+    return context;
+}
+
+@end


### PR DESCRIPTION
This PR deprecates all `inContext:` methods from `NSManagedObject+RZImportable.h`. It used to be the case that you should not actually use some of the `RZImportable` protocol on `NSManagedObject` subclasses, which was frequently confusing. RZImport in RZVinyl will now work by default on the main context / main thread, or inside of `-[NSManagedObjectContext rzi_performImport:]`. This causes an API change in most cases to:
```
[context rzi_performImport:^() {
   NSArray *artists = [Artist rzi_arrayFromObjects:JSON];
}];
```

A benifit of this approach is this will also support importing an NSManagedObject inside an NSObject, for non-persistent state containers (IE: Pagination data).

I'm also pretty sure there will be a way to further simplify this with swift generics to read something like:
```
let artists: [Artist] = context.import(JSON)
```

I imagine this will invoke opinions, so I separated it out from the #75 , which removes the context methods from instance calls and should be less opinionated.