### PR TITLE
RZImport Caching

### DIFF
--- a/Classes/RZCoreDataStack.h
+++ b/Classes/RZCoreDataStack.h
@@ -9,7 +9,7 @@
 //
 //  Permission is hereby granted, free of charge, to any person obtaining
 //  a copy of this software and associated documentation files (the
-//                                                                "Software"), to deal in the Software without restriction, including
+//  "Software"), to deal in the Software without restriction, including
 //  without limitation the rights to use, copy, modify, merge, publish,
 //  distribute, sublicense, and/or sell copies of the Software, and to
 //  permit persons to whom the Software is furnished to do so, subject to
@@ -40,13 +40,13 @@ typedef NS_OPTIONS(NSUInteger, RZCoreDataStackOptions)
      *  or the file will be deleted, depending on whether @p RZCoreDataStackOptionDeleteDatabaseIfUnreadable is
      *  also passed to init.
      */
-    RZCoreDataStackOptionDisableAutoLightweightMigration = (1 << 0),
+    RZCoreDataStackOptionsDisableAutoLightweightMigration = (1 << 0),
     
     /**
      *  Pass this option to delete the database file if it is not readable using the provided model.
      *  If this option is not set and the file is unreadable, the initialization will fail and an exception will be thrown.
      */
-    RZCoreDataStackOptionDeleteDatabaseIfUnreadable = (1 << 1),
+    RZCoreDataStackOptionsDeleteDatabaseIfUnreadable = (1 << 1),
     
     /**
      *  Pass this option to disable the write-ahead log for sqlite databases.

--- a/Classes/RZCoreDataStack.h
+++ b/Classes/RZCoreDataStack.h
@@ -41,12 +41,14 @@ typedef NS_OPTIONS(NSUInteger, RZCoreDataStackOptions)
      *  also passed to init.
      */
     RZCoreDataStackOptionsDisableAutoLightweightMigration = (1 << 0),
+    RZCoreDataStackOptionDisableAutoLightweightMigration __attribute__((deprecated)) = RZCoreDataStackOptionsDisableAutoLightweightMigration,
     
     /**
      *  Pass this option to delete the database file if it is not readable using the provided model.
      *  If this option is not set and the file is unreadable, the initialization will fail and an exception will be thrown.
      */
     RZCoreDataStackOptionsDeleteDatabaseIfUnreadable = (1 << 1),
+    RZCoreDataStackOptionDeleteDatabaseIfUnreadable __attribute((deprecated)) = RZCoreDataStackOptionsDeleteDatabaseIfUnreadable,
     
     /**
      *  Pass this option to disable the write-ahead log for sqlite databases.

--- a/Classes/RZCoreDataStack.m
+++ b/Classes/RZCoreDataStack.m
@@ -356,7 +356,7 @@ static RZCoreDataStack *s_defaultStack = nil;
         options[NSSQLitePragmasOption] = @{@"journal_mode" : journalMode};
     }
     
-    if ( ![self hasOptionsSet:RZCoreDataStackOptionDisableAutoLightweightMigration] && self.storeURL ){
+    if ( ![self hasOptionsSet:RZCoreDataStackOptionsDisableAutoLightweightMigration] && self.storeURL ){
         options[NSMigratePersistentStoresAutomaticallyOption] = @(YES);
         options[NSInferMappingModelAutomaticallyOption] = @(YES);
     }
@@ -368,7 +368,7 @@ static RZCoreDataStack *s_defaultStack = nil;
         
         RZVLogError(@"Error creating/reading persistent store: %@", error);
         
-        if ( [self hasOptionsSet:RZCoreDataStackOptionDeleteDatabaseIfUnreadable] && self.storeURL ) {
+        if ( [self hasOptionsSet:RZCoreDataStackOptionsDeleteDatabaseIfUnreadable] && self.storeURL ) {
             
             // Reset the error before we reuse it
             error = nil;

--- a/Classes/RZVCompatibility.h
+++ b/Classes/RZVCompatibility.h
@@ -56,5 +56,5 @@
 #endif
 
 #define RZVKeyMap RZGeneric(NSDictionary, NSString *, NSString *)
-#define RZVStringDictionary RZGeneric(NSDictionary, NSString *, NSObject *)
+#define RZVStringDictionary RZGeneric(NSDictionary, NSString *, id)
 #define RZVArrayOfStringDict RZGeneric(NSArray, RZVStringDictionary *)

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,2 +1,5 @@
 platform :ios, '7.0'
-pod 'RZVinyl', :path => '../'
+
+target 'RZVinylDemo' do
+  pod 'RZVinyl', :path => '../'
+end

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,3 +3,7 @@ platform :ios, '7.0'
 target 'RZVinylDemo' do
   pod 'RZVinyl', :path => '../'
 end
+
+target 'RZVinylTests' do
+  pod 'RZVinyl', :path => '../'
+end

--- a/Example/RZVinylDemo.xcodeproj/project.pbxproj
+++ b/Example/RZVinylDemo.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		33F22A3C3FFBFF8E3C67E1E2 /* libPods-RZVinylDemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FEF423746B822254A305499 /* libPods-RZVinylDemo.a */; };
+		980CD112B8135D23E7C64BC5 /* libPods-RZVinylTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 18D50CA2333A914AFC99319E /* libPods-RZVinylTests.a */; };
 		9A0133F419586E2B00FED6DC /* RZPersonFiltersViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A0133F319586E2B00FED6DC /* RZPersonFiltersViewController.m */; };
 		9A3DB11C1986F01600E973F0 /* Artist.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DB11B1986F01600E973F0 /* Artist.m */; };
 		9A3DB11F1986F01700E973F0 /* Song.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DB11E1986F01700E973F0 /* Song.m */; };
@@ -68,6 +69,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		18D50CA2333A914AFC99319E /* libPods-RZVinylTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RZVinylTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3D95AAC8D0F565E4E9AA514E /* Pods-RZVinylTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RZVinylTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RZVinylTests/Pods-RZVinylTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5264147DBE4A5E96EA5D6366 /* Pods-RZVinylDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RZVinylDemo.release.xcconfig"; path = "Pods/Target Support Files/Pods-RZVinylDemo/Pods-RZVinylDemo.release.xcconfig"; sourceTree = "<group>"; };
 		6FEF423746B822254A305499 /* libPods-RZVinylDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RZVinylDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D52ED5913F75EA4109405E7 /* Pods-RZVinylDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RZVinylDemo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RZVinylDemo/Pods-RZVinylDemo.debug.xcconfig"; sourceTree = "<group>"; };
@@ -148,6 +151,7 @@
 		9AD8B1CF1944BCE8009C7823 /* RZVinylBaseTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RZVinylBaseTestCase.m; sourceTree = "<group>"; };
 		9AD8B1D11944BD0C009C7823 /* RZVinylBaseTestCase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RZVinylBaseTestCase.h; sourceTree = "<group>"; };
 		AB2E95901A3695D2009DD607 /* RZVinylFRCTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RZVinylFRCTests.m; sourceTree = "<group>"; };
+		CC8B3F3A34C61AEC6421BB29 /* Pods-RZVinylTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RZVinylTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-RZVinylTests/Pods-RZVinylTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -170,6 +174,7 @@
 				9AB90809193FD7F70063445A /* XCTest.framework in Frameworks */,
 				9AB9080B193FD7F70063445A /* UIKit.framework in Frameworks */,
 				9AB9080A193FD7F70063445A /* Foundation.framework in Frameworks */,
+				980CD112B8135D23E7C64BC5 /* libPods-RZVinylTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -181,6 +186,8 @@
 			children = (
 				8D52ED5913F75EA4109405E7 /* Pods-RZVinylDemo.debug.xcconfig */,
 				5264147DBE4A5E96EA5D6366 /* Pods-RZVinylDemo.release.xcconfig */,
+				3D95AAC8D0F565E4E9AA514E /* Pods-RZVinylTests.debug.xcconfig */,
+				CC8B3F3A34C61AEC6421BB29 /* Pods-RZVinylTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -214,6 +221,7 @@
 				9A53612E193F90E000E87F4F /* CoreData.framework */,
 				9A536146193F90E000E87F4F /* XCTest.framework */,
 				6FEF423746B822254A305499 /* libPods-RZVinylDemo.a */,
+				18D50CA2333A914AFC99319E /* libPods-RZVinylTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -457,9 +465,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9AB90819193FD7F70063445A /* Build configuration list for PBXNativeTarget "RZVinylTests" */;
 			buildPhases = (
+				E6A76384BB6A0550B7B5531A /* Check Pods Manifest.lock */,
 				9AB90804193FD7F70063445A /* Sources */,
 				9AB90805193FD7F70063445A /* Frameworks */,
 				9AB90806193FD7F70063445A /* Resources */,
+				6C2841B180CBC379E66AFA65 /* Embed Pods Frameworks */,
+				0028DF38FF8156BE3686A48D /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -529,6 +540,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		0028DF38FF8156BE3686A48D /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RZVinylTests/Pods-RZVinylTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		463615659FC54C9C2C2B97B1 /* Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -542,6 +568,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RZVinylDemo/Pods-RZVinylDemo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6C2841B180CBC379E66AFA65 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RZVinylTests/Pods-RZVinylTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		7BD806C32276F9CCCEEA4908 /* Check Pods Manifest.lock */ = {
@@ -572,6 +613,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RZVinylDemo/Pods-RZVinylDemo-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E6A76384BB6A0550B7B5531A /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -763,6 +819,7 @@
 		};
 		9AB90817193FD7F70063445A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3D95AAC8D0F565E4E9AA514E /* Pods-RZVinylTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/RZVinylDemo.app/RZVinylDemo";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -778,6 +835,7 @@
 		};
 		9AB90818193FD7F70063445A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CC8B3F3A34C61AEC6421BB29 /* Pods-RZVinylTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/RZVinylDemo.app/RZVinylDemo";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/Example/RZVinylDemo.xcodeproj/project.pbxproj
+++ b/Example/RZVinylDemo.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		267E92CF2352486981965091 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BFA85CBDC67442B2A5052135 /* libPods.a */; };
+		33F22A3C3FFBFF8E3C67E1E2 /* libPods-RZVinylDemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FEF423746B822254A305499 /* libPods-RZVinylDemo.a */; };
 		9A0133F419586E2B00FED6DC /* RZPersonFiltersViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A0133F319586E2B00FED6DC /* RZPersonFiltersViewController.m */; };
 		9A3DB11C1986F01600E973F0 /* Artist.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DB11B1986F01600E973F0 /* Artist.m */; };
 		9A3DB11F1986F01700E973F0 /* Song.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A3DB11E1986F01700E973F0 /* Song.m */; };
@@ -68,7 +68,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		321C2A0D52411C920F1C0329 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		5264147DBE4A5E96EA5D6366 /* Pods-RZVinylDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RZVinylDemo.release.xcconfig"; path = "Pods/Target Support Files/Pods-RZVinylDemo/Pods-RZVinylDemo.release.xcconfig"; sourceTree = "<group>"; };
+		6FEF423746B822254A305499 /* libPods-RZVinylDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RZVinylDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8D52ED5913F75EA4109405E7 /* Pods-RZVinylDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RZVinylDemo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RZVinylDemo/Pods-RZVinylDemo.debug.xcconfig"; sourceTree = "<group>"; };
 		9A0133F219586E2B00FED6DC /* RZPersonFiltersViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RZPersonFiltersViewController.h; sourceTree = "<group>"; };
 		9A0133F319586E2B00FED6DC /* RZPersonFiltersViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RZPersonFiltersViewController.m; sourceTree = "<group>"; };
 		9A0133F51958768000FED6DC /* RZTableViewDataSourceBlocks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RZTableViewDataSourceBlocks.h; sourceTree = "<group>"; };
@@ -146,8 +148,6 @@
 		9AD8B1CF1944BCE8009C7823 /* RZVinylBaseTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RZVinylBaseTestCase.m; sourceTree = "<group>"; };
 		9AD8B1D11944BD0C009C7823 /* RZVinylBaseTestCase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RZVinylBaseTestCase.h; sourceTree = "<group>"; };
 		AB2E95901A3695D2009DD607 /* RZVinylFRCTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RZVinylFRCTests.m; sourceTree = "<group>"; };
-		BF9D39F06DB534652E101AEE /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
-		BFA85CBDC67442B2A5052135 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -159,7 +159,7 @@
 				9A53612F193F90E000E87F4F /* CoreData.framework in Frameworks */,
 				9A53612D193F90E000E87F4F /* UIKit.framework in Frameworks */,
 				9A536129193F90E000E87F4F /* Foundation.framework in Frameworks */,
-				267E92CF2352486981965091 /* libPods.a in Frameworks */,
+				33F22A3C3FFBFF8E3C67E1E2 /* libPods-RZVinylDemo.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -176,14 +176,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5F477376E0B15C00FDCE97D4 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				8D52ED5913F75EA4109405E7 /* Pods-RZVinylDemo.debug.xcconfig */,
+				5264147DBE4A5E96EA5D6366 /* Pods-RZVinylDemo.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		9A53611C193F90E000E87F4F = {
 			isa = PBXGroup;
 			children = (
-				9A536130193F90E000E87F4F /* RZVinylDemo */,
-				9AB9080C193FD7F70063445A /* RZVinylTests */,
 				9A536127193F90E000E87F4F /* Frameworks */,
 				9A536126193F90E000E87F4F /* Products */,
-				E27915038CB108E7F2C093D4 /* Pods */,
+				9A536130193F90E000E87F4F /* RZVinylDemo */,
+				9AB9080C193FD7F70063445A /* RZVinylTests */,
+				5F477376E0B15C00FDCE97D4 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -204,7 +213,7 @@
 				9A53612C193F90E000E87F4F /* UIKit.framework */,
 				9A53612E193F90E000E87F4F /* CoreData.framework */,
 				9A536146193F90E000E87F4F /* XCTest.framework */,
-				BFA85CBDC67442B2A5052135 /* libPods.a */,
+				6FEF423746B822254A305499 /* libPods-RZVinylDemo.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -226,10 +235,10 @@
 		9A536131193F90E000E87F4F /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				9A536132193F90E000E87F4F /* RZVinylDemo-Info.plist */,
 				9A536133193F90E000E87F4F /* InfoPlist.strings */,
-				9A536136193F90E000E87F4F /* main.m */,
+				9A536132193F90E000E87F4F /* RZVinylDemo-Info.plist */,
 				9A536138193F90E000E87F4F /* RZVinylDemo-Prefix.pch */,
+				9A536136193F90E000E87F4F /* main.m */,
 			);
 			path = "Supporting Files";
 			sourceTree = "<group>";
@@ -248,8 +257,8 @@
 		9A53615E193F91DF00E87F4F /* Data */ = {
 			isa = PBXGroup;
 			children = (
-				9A75DB9119538E0C00173911 /* Sources */,
 				9A75DB9019538E0000173911 /* Model */,
+				9A75DB9119538E0C00173911 /* Sources */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -257,8 +266,8 @@
 		9A53615F193F91E700E87F4F /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				9A75DB8B195388D700173911 /* person_data.json */,
 				9A53613F193F90E000E87F4F /* Images.xcassets */,
+				9A75DB8B195388D700173911 /* person_data.json */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -266,12 +275,12 @@
 		9A536160193F91ED00E87F4F /* View Controllers */ = {
 			isa = PBXGroup;
 			children = (
-				9A75DB8D19538D3200173911 /* RZPersonListViewController.h */,
-				9A75DB8E19538D3200173911 /* RZPersonListViewController.m */,
-				9A0133F219586E2B00FED6DC /* RZPersonFiltersViewController.h */,
-				9A0133F319586E2B00FED6DC /* RZPersonFiltersViewController.m */,
 				9A839F9E1958B0FE00450792 /* RZPersonDetailViewController.h */,
 				9A839F9F1958B0FE00450792 /* RZPersonDetailViewController.m */,
+				9A0133F219586E2B00FED6DC /* RZPersonFiltersViewController.h */,
+				9A0133F319586E2B00FED6DC /* RZPersonFiltersViewController.m */,
+				9A75DB8D19538D3200173911 /* RZPersonListViewController.h */,
+				9A75DB8E19538D3200173911 /* RZPersonListViewController.m */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -280,13 +289,13 @@
 			isa = PBXGroup;
 			children = (
 				9A75DB95195392A500173911 /* Extensions */,
-				9A53613C193F90E000E87F4F /* RZVinylDemo.xcdatamodeld */,
-				9A75DBBC1954AD7900173911 /* RZInterest.h */,
-				9A75DBBD1954AD7900173911 /* RZInterest.m */,
 				9A75DBB91954AD7900173911 /* RZAddress.h */,
 				9A75DBBA1954AD7900173911 /* RZAddress.m */,
+				9A75DBBC1954AD7900173911 /* RZInterest.h */,
+				9A75DBBD1954AD7900173911 /* RZInterest.m */,
 				9A75DBB61954AD7800173911 /* RZPerson.h */,
 				9A75DBB71954AD7800173911 /* RZPerson.m */,
+				9A53613C193F90E000E87F4F /* RZVinylDemo.xcdatamodeld */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -294,11 +303,11 @@
 		9A75DB9119538E0C00173911 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				9A0133F51958768000FED6DC /* RZTableViewDataSourceBlocks.h */,
 				9A75DB9219538E1E00173911 /* RZFetchedPersonDataSource.h */,
 				9A75DB9319538E1E00173911 /* RZFetchedPersonDataSource.m */,
 				9AD76DB8195886B8003B62D2 /* RZPersonFiltersDataSource.h */,
 				9AD76DB9195886B8003B62D2 /* RZPersonFiltersDataSource.m */,
+				9A0133F51958768000FED6DC /* RZTableViewDataSourceBlocks.h */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -306,12 +315,12 @@
 		9A75DB95195392A500173911 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				9A75DBBF1954ADA200173911 /* RZPerson+RZVinyl.h */,
-				9A75DBC01954ADA200173911 /* RZPerson+RZVinyl.m */,
-				9A75DBC51954E02B00173911 /* RZInterest+RZVinyl.h */,
-				9A75DBC61954E02B00173911 /* RZInterest+RZVinyl.m */,
 				9A75DBC81954E0C600173911 /* RZAddress+RZVinyl.h */,
 				9A75DBC91954E0C600173911 /* RZAddress+RZVinyl.m */,
+				9A75DBC51954E02B00173911 /* RZInterest+RZVinyl.h */,
+				9A75DBC61954E02B00173911 /* RZInterest+RZVinyl.m */,
+				9A75DBBF1954ADA200173911 /* RZPerson+RZVinyl.h */,
+				9A75DBC01954ADA200173911 /* RZPerson+RZVinyl.m */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -330,11 +339,11 @@
 		9A75DBA31954A7EE00173911 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				9A60C6A619588C27006E976A /* RZFilterTableViewCell.h */,
+				9A60C6A719588C27006E976A /* RZFilterTableViewCell.m */,
 				9A75DBA41954A7EE00173911 /* RZPersonTableViewCell.h */,
 				9A75DBA51954A7EE00173911 /* RZPersonTableViewCell.m */,
 				9A75DBA61954A7EE00173911 /* RZPersonTableViewCell.xib */,
-				9A60C6A619588C27006E976A /* RZFilterTableViewCell.h */,
-				9A60C6A719588C27006E976A /* RZFilterTableViewCell.m */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -353,15 +362,15 @@
 			children = (
 				9AB908231940D7AC0063445A /* Model */,
 				9AB90888194113B50063445A /* Resources */,
+				9AB9080D193FD7F70063445A /* Supporting Files */,
 				9AB9088719410A320063445A /* Utils */,
 				9AB9081A193FD8330063445A /* RZCoreDataStackConfigTests.m */,
 				9AD8B1D11944BD0C009C7823 /* RZVinylBaseTestCase.h */,
 				9AD8B1CF1944BCE8009C7823 /* RZVinylBaseTestCase.m */,
+				AB2E95901A3695D2009DD607 /* RZVinylFRCTests.m */,
+				9AD8B1CD1944BBD8009C7823 /* RZVinylImportTests.m */,
 				9AB90875194104860063445A /* RZVinylRecordTests.m */,
 				9AB3ABF2195BAFD40014D5FF /* RZVinylSaveTests.m */,
-				9AD8B1CD1944BBD8009C7823 /* RZVinylImportTests.m */,
-				AB2E95901A3695D2009DD607 /* RZVinylFRCTests.m */,
-				9AB9080D193FD7F70063445A /* Supporting Files */,
 			);
 			path = RZVinylTests;
 			sourceTree = "<group>";
@@ -369,8 +378,8 @@
 		9AB9080D193FD7F70063445A /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				9AB9080E193FD7F70063445A /* RZVinylTests-Info.plist */,
 				9AB9080F193FD7F70063445A /* InfoPlist.strings */,
+				9AB9080E193FD7F70063445A /* RZVinylTests-Info.plist */,
 				9AB90814193FD7F70063445A /* RZVinylTests-Prefix.pch */,
 			);
 			path = "Supporting Files";
@@ -380,13 +389,13 @@
 			isa = PBXGroup;
 			children = (
 				9AB90880194107AA0063445A /* RZVinylExtensions */,
-				9AB908241940D7BC0063445A /* TestModel.xcdatamodeld */,
+				9A3DB11A1986F01600E973F0 /* Artist.h */,
+				9A3DB11B1986F01600E973F0 /* Artist.m */,
 				9A3DB1201986F01700E973F0 /* BaseObject.h */,
 				9A3DB1211986F01700E973F0 /* BaseObject.m */,
 				9A3DB11D1986F01700E973F0 /* Song.h */,
 				9A3DB11E1986F01700E973F0 /* Song.m */,
-				9A3DB11A1986F01600E973F0 /* Artist.h */,
-				9A3DB11B1986F01600E973F0 /* Artist.m */,
+				9AB908241940D7BC0063445A /* TestModel.xcdatamodeld */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -394,10 +403,10 @@
 		9AB90880194107AA0063445A /* RZVinylExtensions */ = {
 			isa = PBXGroup;
 			children = (
-				9AB90881194107C30063445A /* BaseObject+RZVinyl.h */,
-				9AB90882194107C30063445A /* BaseObject+RZVinyl.m */,
 				9A74A5C61946488100A06937 /* Artist+RZVinyl.h */,
 				9A74A5C71946488100A06937 /* Artist+RZVinyl.m */,
+				9AB90881194107C30063445A /* BaseObject+RZVinyl.h */,
+				9AB90882194107C30063445A /* BaseObject+RZVinyl.m */,
 			);
 			path = RZVinylExtensions;
 			sourceTree = "<group>";
@@ -405,10 +414,10 @@
 		9AB9088719410A320063445A /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				9AB9088419410A2D0063445A /* RZWaiter.h */,
-				9AB9088519410A2D0063445A /* RZWaiter.m */,
 				9A95F0F31948DC8B00139457 /* RZCoreDataStack+TestUtils.h */,
 				9A95F0F41948DC8B00139457 /* RZCoreDataStack+TestUtils.m */,
+				9AB9088419410A2D0063445A /* RZWaiter.h */,
+				9AB9088519410A2D0063445A /* RZWaiter.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -421,15 +430,6 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
-		E27915038CB108E7F2C093D4 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				BF9D39F06DB534652E101AEE /* Pods.debug.xcconfig */,
-				321C2A0D52411C920F1C0329 /* Pods.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -437,12 +437,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9A536157193F90E000E87F4F /* Build configuration list for PBXNativeTarget "RZVinylDemo" */;
 			buildPhases = (
-				3D176FFBC4A447639F30E5EC /* Check Pods Manifest.lock */,
+				7BD806C32276F9CCCEEA4908 /* Check Pods Manifest.lock */,
 				9A536121193F90E000E87F4F /* Sources */,
 				9A536122193F90E000E87F4F /* Frameworks */,
 				9A536123193F90E000E87F4F /* Resources */,
-				9B01E010DBBE44C59D6011E5 /* Copy Pods Resources */,
-				043D488D2E5A502727E45355 /* Embed Pods Frameworks */,
+				463615659FC54C9C2C2B97B1 /* Embed Pods Frameworks */,
+				C8EA63AADA7257ED79981760 /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -529,7 +529,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		043D488D2E5A502727E45355 /* Embed Pods Frameworks */ = {
+		463615659FC54C9C2C2B97B1 /* Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -541,10 +541,10 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RZVinylDemo/Pods-RZVinylDemo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		3D176FFBC4A447639F30E5EC /* Check Pods Manifest.lock */ = {
+		7BD806C32276F9CCCEEA4908 /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -559,7 +559,7 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		9B01E010DBBE44C59D6011E5 /* Copy Pods Resources */ = {
+		C8EA63AADA7257ED79981760 /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -571,7 +571,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RZVinylDemo/Pods-RZVinylDemo-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -641,6 +641,7 @@
 				9A536134193F90E000E87F4F /* en */,
 			);
 			name = InfoPlist.strings;
+			path = .;
 			sourceTree = "<group>";
 		};
 		9AB9080F193FD7F70063445A /* InfoPlist.strings */ = {
@@ -649,6 +650,7 @@
 				9AB90810193FD7F70063445A /* en */,
 			);
 			name = InfoPlist.strings;
+			path = .;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */
@@ -729,7 +731,7 @@
 		};
 		9A536158193F90E000E87F4F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BF9D39F06DB534652E101AEE /* Pods.debug.xcconfig */;
+			baseConfigurationReference = 8D52ED5913F75EA4109405E7 /* Pods-RZVinylDemo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -745,7 +747,7 @@
 		};
 		9A536159193F90E000E87F4F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 321C2A0D52411C920F1C0329 /* Pods.release.xcconfig */;
+			baseConfigurationReference = 5264147DBE4A5E96EA5D6366 /* Pods-RZVinylDemo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -761,7 +763,6 @@
 		};
 		9AB90817193FD7F70063445A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BF9D39F06DB534652E101AEE /* Pods.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/RZVinylDemo.app/RZVinylDemo";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -777,7 +778,6 @@
 		};
 		9AB90818193FD7F70063445A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 321C2A0D52411C920F1C0329 /* Pods.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/RZVinylDemo.app/RZVinylDemo";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/Example/RZVinylDemo.xcodeproj/xcshareddata/xcschemes/RZVinylDemo.xcscheme
+++ b/Example/RZVinylDemo.xcodeproj/xcshareddata/xcschemes/RZVinylDemo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/RZVinylDemo/Application/RZAppDelegate.m
+++ b/Example/RZVinylDemo/Application/RZAppDelegate.m
@@ -15,7 +15,7 @@ static NSString* const kRZManagedObjectModelName = @"RZVinylDemo";
 
 - (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    RZCoreDataStackOptions options = RZCoreDataStackOptionDeleteDatabaseIfUnreadable | RZCoreDataStackOptionsEnableAutoStalePurge;
+    RZCoreDataStackOptions options = RZCoreDataStackOptionsDeleteDatabaseIfUnreadable | RZCoreDataStackOptionsEnableAutoStalePurge;
     [RZCoreDataStack setDefaultStack:[[RZCoreDataStack alloc] initWithModelName:kRZManagedObjectModelName
                                                                   configuration:nil
                                                                       storeType:NSInMemoryStoreType

--- a/Example/RZVinylTests/RZCoreDataStackConfigTests.m
+++ b/Example/RZVinylTests/RZCoreDataStackConfigTests.m
@@ -178,7 +178,7 @@ static NSString* const kRZCoreDataStackCustomFilePath = @"test_tmp/RZCoreDataSta
                                                            storeType:NSSQLiteStoreType
                                                             storeURL:self.customFileURL
                                           persistentStoreCoordinator:nil
-                                                             options:RZCoreDataStackOptionDisableAutoLightweightMigration], @"Init with unreadable model should throw an exception");
+                                                             options:RZCoreDataStackOptionsDisableAutoLightweightMigration], @"Init with unreadable model should throw an exception");
     
     XCTAssertNil(stack2, @"Database should be unreadable with this model");
     
@@ -186,7 +186,7 @@ static NSString* const kRZCoreDataStackCustomFilePath = @"test_tmp/RZCoreDataSta
                                                            storeType:NSSQLiteStoreType
                                                             storeURL:self.customFileURL
                                           persistentStoreCoordinator:nil
-                                                             options:RZCoreDataStackOptionDeleteDatabaseIfUnreadable], @"Init threw an exception");
+                                                             options:RZCoreDataStackOptionsDeleteDatabaseIfUnreadable], @"Init threw an exception");
     
     XCTAssertNotNil(stack2, @"Stack should have been deleted and rebuilt");
     XCTAssertNotNil(stack2.managedObjectModel, @"Model should not be nil");

--- a/Example/RZVinylTests/RZVinylBaseTestCase.h
+++ b/Example/RZVinylTests/RZVinylBaseTestCase.h
@@ -10,10 +10,6 @@
 #import "Song.h"
 #import "RZWaiter.h"
 
-// Declaration of benchmark function from libdispatch
-// http://nshipster.com/benchmarking/
-extern uint64_t dispatch_benchmark(size_t count, void (^block)(void));
-
 @interface RZVinylBaseTestCase : XCTestCase
 
 @property (nonatomic, readonly, strong) RZCoreDataStack *stack;

--- a/Example/RZVinylTests/RZVinylSaveTests.m
+++ b/Example/RZVinylTests/RZVinylSaveTests.m
@@ -39,7 +39,7 @@
                                                       storeType:NSSQLiteStoreType
                                                        storeURL:nil
                                      persistentStoreCoordinator:nil
-                                                        options:RZCoreDataStackOptionDeleteDatabaseIfUnreadable];
+                                                        options:RZCoreDataStackOptionsDeleteDatabaseIfUnreadable];
 }
 
 #pragma mark - Tests

--- a/Example/RZVinylTests/Utils/RZWaiter.h
+++ b/Example/RZVinylTests/Utils/RZWaiter.h
@@ -1,6 +1,6 @@
 //
 //  RZWaiter.h
-//  Costco
+//  RZVinylDemo
 //
 //  Created by Nick Bonatsakis on 06/19/2013.
 //  Copyright (c) 2014 RaizLabs. All rights reserved.

--- a/Example/RZVinylTests/Utils/RZWaiter.m
+++ b/Example/RZVinylTests/Utils/RZWaiter.m
@@ -1,6 +1,6 @@
 //
 //  RZWaiter.h
-//  Costco
+//  RZVinylDemo
 //
 //  Created by Nick Bonatsakis on 06/19/2013.
 //  Copyright (c) 2014 RaizLabs. All rights reserved.

--- a/Extensions/NSManagedObject+RZImport.h
+++ b/Extensions/NSManagedObject+RZImport.h
@@ -146,7 +146,23 @@
  *  @return A valid NSManagedObject initialized with the provided dictionary, or nil
  *          if an object could not be created.
  */
-+ (RZNullable id)rzi_existingObjectForDict:(RZVStringDictionary* RZCNonnull)dict inContext:(NSManagedObjectContext* RZCNonnull)context;
++ (RZNullable instancetype)rzi_existingObjectForDict:(RZVStringDictionary* RZCNonnull)dict inContext:(NSManagedObjectContext* RZCNonnull)context;
+
+/**
+ *  Access to objects cached by RZImport with an option to create a new object if the cache is empty. This method
+ *  will create a new object if @p createNew is true and the object is not in the cache. Make sure the cache is warmed
+ *  up before using this method.
+ *
+ *  @param primaryKeyValue The primary key to lookup with. If the value is NSNull, this method will return nil.
+ *  @param createNew If the object is not found and this flag is set to YES, create a new object.
+ *  @param context The managed object context in which to find/insert the object.
+ *
+ *
+ *  @return A valid NSManagedObject initialized with the provided primaryKeyValue, or nil
+ *          if an object could not be created.
+ */
+
++ (RZNullable instancetype)rzi_cachedObjectForPrimaryKey:(id RZCNonnull)primaryKeyValue createNew:(BOOL)createNew inContext:(NSManagedObjectContext * RZCNonnull)context;
 
 @end
 

--- a/Extensions/NSManagedObject+RZImport.h
+++ b/Extensions/NSManagedObject+RZImport.h
@@ -153,22 +153,6 @@
  */
 + (RZNullable instancetype)rzi_existingObjectForDict:(RZVStringDictionary* RZCNonnull)dict inContext:(NSManagedObjectContext* RZCNonnull)context;
 
-/**
- *  Access to objects cached by RZImport with an option to create a new object if the cache is empty. This method
- *  will create a new object if @p createNew is true and the object is not in the cache. Make sure the cache is warmed
- *  up before using this method.
- *
- *  @param primaryKeyValue The primary key to lookup with. If the value is NSNull, this method will return nil.
- *  @param createNew If the object is not found and this flag is set to YES, create a new object.
- *  @param context The managed object context in which to find/insert the object.
- *
- *
- *  @return A valid NSManagedObject initialized with the provided primaryKeyValue, or nil
- *          if an object could not be created.
- */
-
-+ (RZNullable instancetype)rzi_cachedObjectForPrimaryKey:(id RZCNonnull)primaryKeyValue createNew:(BOOL)createNew inContext:(NSManagedObjectContext * RZCNonnull)context;
-
 @end
 
 /**

--- a/Extensions/NSManagedObject+RZImportableSubclass.h
+++ b/Extensions/NSManagedObject+RZImportableSubclass.h
@@ -41,8 +41,7 @@
  *  but your managed object subclass might store this value as an attribute named "remoteID", hence it is 
  *  necessary to provide both keys separately to enforce unique instances in the database.
  *
- *  @note Failure to override (or returning nil, the default) will cause the value of @p +rzv_primaryKey
- *  to be used for the external key as well.
+ *  @note This will return the value of @p +rzv_primaryKey if it is this method is not over-ridden.
  *
  *  @return The key in dictionary representations whose value uniquely identifies this object.
  */
@@ -57,5 +56,8 @@
  *  @return @c YES to always create new instances on import. Default is @c NO.
  */
 + (BOOL)rzv_shouldAlwaysCreateNewObjectOnImport;
+
+
++ (NSArray *)rzv_externalCacheKeys;
 
 @end

--- a/Extensions/NSManagedObject+RZImportableSubclass.h
+++ b/Extensions/NSManagedObject+RZImportableSubclass.h
@@ -41,7 +41,7 @@
  *  but your managed object subclass might store this value as an attribute named "remoteID", hence it is 
  *  necessary to provide both keys separately to enforce unique instances in the database.
  *
- *  @note This will return the value of @p +rzv_primaryKey if it is this method is not overridden.
+ *  @note This will return the value of @c +rzv_primaryKey if it is this method is not overridden.
  *
  *  @return The key in dictionary representations whose value uniquely identifies this object.
  */
@@ -61,6 +61,8 @@
  *  When caching managed objects, the cache will be built for the keys specified. By default `rzv_externalPrimaryKey`
  *  is returned. Subclasses can add cache lookups for other keys by overriding this method and returning the keys.
  *  This is useful when a different key is used elsewhere in your object graph for associations.
+ *
+ *  @return An array of external keys to build the cache with.
  */
 + (NSArray *)rzv_externalCacheKeys;
 

--- a/Extensions/NSManagedObject+RZImportableSubclass.h
+++ b/Extensions/NSManagedObject+RZImportableSubclass.h
@@ -41,7 +41,7 @@
  *  but your managed object subclass might store this value as an attribute named "remoteID", hence it is 
  *  necessary to provide both keys separately to enforce unique instances in the database.
  *
- *  @note This will return the value of @p +rzv_primaryKey if it is this method is not over-ridden.
+ *  @note This will return the value of @p +rzv_primaryKey if it is this method is not overridden.
  *
  *  @return The key in dictionary representations whose value uniquely identifies this object.
  */
@@ -57,7 +57,11 @@
  */
 + (BOOL)rzv_shouldAlwaysCreateNewObjectOnImport;
 
-
+/** 
+ *  When caching managed objects, the cache will be built for the keys specified. By default `rzv_externalPrimaryKey`
+ *  is returned. Subclasses can add cache lookups for other keys by overriding this method and returning the keys.
+ *  This is useful when a different key is used elsewhere in your object graph for associations.
+ */
 + (NSArray *)rzv_externalCacheKeys;
 
 @end

--- a/Extensions/NSManagedObject+RZImportableSubclass.m
+++ b/Extensions/NSManagedObject+RZImportableSubclass.m
@@ -41,4 +41,10 @@
     return NO;
 }
 
+- (void)rzi_setNilForPropertyNamed:(NSString *)propName;
+{
+    // NSManagedObject's handle setNilValueForKey: so this is safe, and faster.
+    [self setValue:nil forKey:propName];
+}
+
 @end

--- a/Extensions/NSManagedObject+RZImportableSubclass.m
+++ b/Extensions/NSManagedObject+RZImportableSubclass.m
@@ -27,18 +27,24 @@
 //  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #import "NSManagedObject+RZImportableSubclass.h"
+#import "NSManagedObject+RZVinylRecord.h"
 #import "RZVinylDefines.h"
 
 @implementation NSManagedObject (RZImportableSubclass)
 
 + (NSString *)rzv_externalPrimaryKey
 {
-    return nil;
+    return [self rzv_primaryKey];
 }
 
 + (BOOL)rzv_shouldAlwaysCreateNewObjectOnImport
 {
     return NO;
+}
+
++ (NSArray *)rzv_externalCacheKeys
+{
+    return @[[self rzv_externalPrimaryKey]];
 }
 
 @end

--- a/Extensions/NSManagedObject+RZImportableSubclass.m
+++ b/Extensions/NSManagedObject+RZImportableSubclass.m
@@ -43,7 +43,7 @@
 
 - (void)rzi_setNilForPropertyNamed:(NSString *)propName;
 {
-    // NSManagedObject's handle setNilValueForKey: so this is safe, and faster.
+    // NSManagedObjects handle setNilValueForKey: so this is safe, and faster.
     [self setValue:nil forKey:propName];
 }
 

--- a/Extensions/NSManagedObjectContext+RZImport.h
+++ b/Extensions/NSManagedObjectContext+RZImport.h
@@ -34,6 +34,8 @@
  *  Specify that this managed object context should be used for all subsequent
  *  RZImport operations. This enables RZImport to work with NSObjects containing
  *  NSManagedObjects.
+ *
+ *  @param importBlock A block to execute where the import context will be set to this managed object context.
  */
 - (void)rzi_performImport:(void(^)(void))importBlock;
 
@@ -44,19 +46,22 @@
 + (NSManagedObjectContext *)rzi_currentThreadImportContext;
 
 /**
- *  Cache all objects that are in the context.
+ *  Lookup all objects that belong to the entity and cache them.
  *
- *  NOTE: If this is called on the main context of the core data stack, this method will assert.
+ *  @note If this is called on the main context of the core data stack, this method will assert.
+ *
+ *  @param entityClass A subclass of NSManagedObject to cache.
  */
-- (void)rzi_cacheAllObjectsForEntityName:(Class)entityClass;
+- (void)rzi_cacheAllObjectsForEntity:(Class)entityClass;
 
 /**
  *  Cache a specific set of objects for the given entity.
  *
- *  WARNING: Make sure that the objects cached contain all possibilities for the import
- *  associations, otherwise duplicate objects may be created.
+ *  @warning Make sure that the objects cached contain all possibilities for the import
+ *           associations, otherwise duplicate objects may be created.
  *
- *  NOTE: If this is called on the main context of the core data stack, this method will assert.
+ *  @param objects An array of objects to cache. All of these objects are of class entityClass.
+ *  @param entityClass A subclass of NSManagedObject to cache.
  */
 - (void)rzi_cacheObjects:(NSArray *)objects forEntity:(Class)entityClass;
 

--- a/Extensions/NSManagedObjectContext+RZImport.h
+++ b/Extensions/NSManagedObjectContext+RZImport.h
@@ -43,4 +43,26 @@
  */
 + (NSManagedObjectContext *)rzi_currentThreadImportContext;
 
+/**
+ *  Cache all objects that are in the context.
+ */
+- (void)rzi_cacheAllObjectsForEntityName:(Class)entityClass;
+
+/**
+ *  Cache a specific set of objects for the given entity
+ */
+- (void)rzi_cacheObjects:(NSArray *)objects forEntity:(Class)entityClass;
+
+/**
+ *  Load cache from the import data. Ensure that an object exists for
+ *  every primary key value in the importData, looking up, or creating objects 
+ *  as needed. All of the cached objects are returned.
+ */
+- (void)rzi_loadCacheWithImportData:(NSArray *)importData forEntity:(Class)entityClass;
+
+/**
+ *  Lookup an object in the cache with the specified primary key value.
+ */
+- (NSManagedObject *)rzi_cachedObjectForEntity:(Class)entityClass forPrimaryKeyValue:(id)key;
+
 @end

--- a/Extensions/NSManagedObjectContext+RZImport.h
+++ b/Extensions/NSManagedObjectContext+RZImport.h
@@ -42,6 +42,8 @@
 /**
  *  The managed object context that is being imported to. This is set internally
  *  and by the `rzi_performImport:` method.
+ *
+ *  @return the thread-local managed object context
  */
 + (NSManagedObjectContext *)rzi_currentThreadImportContext;
 

--- a/Extensions/NSManagedObjectContext+RZImport.m
+++ b/Extensions/NSManagedObjectContext+RZImport.m
@@ -58,9 +58,14 @@ static NSString * const kRZVinylImportThreadContextKey = @"RZVinylImportThreadCo
     NSParameterAssert(importBlock);
     NSThread *thread = [NSThread currentThread];
     NSManagedObjectContext *initialImportContext = [thread rzi_currentImportContext];
-    [thread rzi_setCurrentImportContext:self];
-    [self performBlockAndWait:importBlock];
-    [thread rzi_setCurrentImportContext:initialImportContext];
+    if (initialImportContext != self) {
+        [thread rzi_setCurrentImportContext:self];
+        [self performBlockAndWait:importBlock];
+        [thread rzi_setCurrentImportContext:initialImportContext];
+    }
+    else {
+        importBlock();
+    }
 }
 
 + (NSManagedObjectContext *)rzi_currentThreadImportContext

--- a/Extensions/NSManagedObjectContext+RZImport.m
+++ b/Extensions/NSManagedObjectContext+RZImport.m
@@ -125,7 +125,8 @@ static NSString * const kRZVinylImportCacheContextKey = @"RZVinylImportCacheCont
 - (void)rzi_cacheObjects:(NSArray *)objects forEntity:(Class)entityClass
 {
     for ( NSString *externalKey in [entityClass rzv_externalCacheKeys] ) {
-        RZIPropertyInfo *info = [entityClass rzi_propertyInfoForExternalKey:externalKey withMappings:nil];
+        NSDictionary *pkMapping = @{[entityClass rzv_externalPrimaryKey]: [entityClass rzv_primaryKey]};
+        RZIPropertyInfo *info = [entityClass rzi_propertyInfoForExternalKey:externalKey withMappings:pkMapping];
         NSAssert(info != nil, @"Unable to find property for external key %@", externalKey);
         NSArray *keys = [objects valueForKey:info.propertyName];
         NSDictionary *values = [NSDictionary dictionaryWithObjects:objects

--- a/Extensions/NSManagedObjectContext+RZImport.m
+++ b/Extensions/NSManagedObjectContext+RZImport.m
@@ -26,12 +26,18 @@
 //  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 //  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#import "NSManagedObject+RZVinylUtils.h"
+#import "NSManagedObject+RZVinylRecord.h"
+#import "NSManagedObject+RZImport.h"
+#import "NSManagedObject+RZImportableSubclass.h"
+
 #import "NSManagedObjectContext+RZImport.h"
 #import "RZCoreDataStack.h"
 
 @implementation NSThread (RZImport)
 
 static NSString * const kRZVinylImportThreadContextKey = @"RZVinylImportThreadContext";
+static NSString * const kRZVinylImportCacheContextKey = @"RZVinylImportCacheContextKey";
 
 - (NSManagedObjectContext *)rzi_currentImportContext
 {
@@ -71,6 +77,79 @@ static NSString * const kRZVinylImportThreadContextKey = @"RZVinylImportThreadCo
     }
     NSAssert(context != nil, @"RZImport is attempting to perform an import with out an import context. Make sure that you use RZImport from inside -[NSManagedObjectContext rzi_performImport].");
     return context;
+}
+
+- (NSMutableDictionary *)rzi_cacheByEntityName
+{
+    NSMutableDictionary *dictionary = self.userInfo[kRZVinylImportCacheContextKey];
+    if (dictionary == nil) {
+        dictionary = [NSMutableDictionary dictionary];
+        self.userInfo[kRZVinylImportCacheContextKey] = dictionary;
+    }
+    return dictionary;
+}
+
+- (NSMutableDictionary *)rzi_cacheForEntity:(Class)entityClass
+{
+    NSMutableDictionary *cachedObjects = self.rzi_cacheByEntityName[[entityClass rzv_entityName]];
+    if (cachedObjects == nil) {
+        cachedObjects = [NSMutableDictionary dictionary];
+        self.rzi_cacheByEntityName[[entityClass rzv_entityName]] = cachedObjects;
+    }
+    return cachedObjects;
+}
+
+- (void)rzi_cacheObjects:(NSArray *)objects forEntity:(Class)entityClass
+{
+    NSArray *keys = [objects valueForKey:[entityClass rzv_primaryKey]];
+    NSDictionary *values = [NSDictionary dictionaryWithObjects:objects
+                                                       forKeys:keys];
+    NSMutableDictionary *cachedObjects = [self rzi_cacheForEntity:entityClass];
+    [cachedObjects setValuesForKeysWithDictionary:values];
+}
+
+- (void)rzi_loadCacheWithImportData:(NSArray *)importData forEntity:(Class)entityClass
+{
+    NSMutableDictionary *cachedObjects = [self rzi_cacheForEntity:entityClass];
+
+    NSString *primaryKey = [entityClass rzv_primaryKey];
+    NSString *externalPrimaryKey = [entityClass rzv_externalPrimaryKey] ?: primaryKey;
+
+    // Determine the primary keys by the external key, and remove duplicates in importData
+    NSArray *keyValues = [importData valueForKey:externalPrimaryKey];
+    NSMutableSet *neededKeyValues = [NSMutableSet setWithArray:keyValues];
+
+    // Look up the objects in the cache.
+    for (id keyValue in [neededKeyValues copy]) {
+        id cache = cachedObjects[keyValue];
+        if (cache) {
+            [neededKeyValues removeObject:keyValue];
+        }
+    }
+
+    // If keys do not have objects, look them up
+    if (neededKeyValues.count > 0) {
+        NSPredicate *existingObjPred = [NSPredicate predicateWithFormat:@"%K in %@", [entityClass rzv_primaryKey], neededKeyValues];
+        NSArray     *existingObjects = [entityClass rzv_where:existingObjPred inContext:self];
+
+        for (id object in existingObjects) {
+            id keyValue = [object valueForKey:primaryKey];
+            [neededKeyValues removeObject:keyValue];
+            [cachedObjects setObject:object forKey:keyValue];
+        }
+    }
+}
+
+- (void)rzi_cacheAllObjectsForEntityName:(Class)entityClass
+{
+    NSArray *objects = [entityClass rzv_allInContext:self];
+    [self rzi_cacheObjects:objects forEntity:entityClass];
+}
+
+- (NSManagedObject *)rzi_cachedObjectForEntity:(Class)entityClass forPrimaryKeyValue:(id)keyValue;
+{
+    NSMutableDictionary *cachedObjects = [self rzi_cacheForEntity:entityClass];
+    return cachedObjects[keyValue];
 }
 
 @end

--- a/Extensions/NSManagedObjectContext+RZImport.m
+++ b/Extensions/NSManagedObjectContext+RZImport.m
@@ -108,10 +108,10 @@ static NSString * const kRZVinylImportCacheContextKey = @"RZVinylImportCacheCont
     if (!RZVAssertOffMainContext()) {
         return nil;
     }
-    NSMutableDictionary *entityCache = self.rzi_cacheByEntityName[[entityClass rzv_entityName]];
+    NSMutableDictionary *entityCache = self.rzi_cacheByEntityName[NSStringFromClass(entityClass)];
     if (entityCache == nil) {
         entityCache = [NSMutableDictionary dictionary];
-        self.rzi_cacheByEntityName[[entityClass rzv_entityName]] = entityCache;
+        self.rzi_cacheByEntityName[NSStringFromClass(entityClass)] = entityCache;
     }
     NSMutableDictionary *entityKeyCache = entityCache[key];
     if (entityKeyCache == nil) {
@@ -162,7 +162,7 @@ static NSString * const kRZVinylImportCacheContextKey = @"RZVinylImportCacheCont
 
 - (BOOL)rzi_isCacheEnabledForEntity:(Class)entityClass;
 {
-    return [self.rzi_cacheByEntityName objectForKey:[entityClass rzv_entityName]] != nil;
+    return [self.rzi_cacheByEntityName objectForKey:NSStringFromClass(entityClass)] != nil;
 }
 
 - (void)rzi_disableCacheForEntity:(Class)entityClass
@@ -170,7 +170,7 @@ static NSString * const kRZVinylImportCacheContextKey = @"RZVinylImportCacheCont
     if (!RZVAssertOffMainContext()) {
         return;
     }
-    [self.rzi_cacheByEntityName removeObjectForKey:[entityClass rzv_entityName]];
+    [self.rzi_cacheByEntityName removeObjectForKey:NSStringFromClass(entityClass)];
 }
 
 @end

--- a/Extensions/NSManagedObjectContext+RZImport.m
+++ b/Extensions/NSManagedObjectContext+RZImport.m
@@ -93,7 +93,7 @@ static NSString * const kRZVinylImportCacheContextKey = @"RZVinylImportCacheCont
     return context;
 }
 
-- (NSMutableDictionary *)rzi_cacheByEntityName
+- (NSMutableDictionary *)rzi_cacheByEntity
 {
     NSMutableDictionary *dictionary = self.userInfo[kRZVinylImportCacheContextKey];
     if (dictionary == nil) {
@@ -108,10 +108,10 @@ static NSString * const kRZVinylImportCacheContextKey = @"RZVinylImportCacheCont
     if (!RZVAssertOffMainContext()) {
         return nil;
     }
-    NSMutableDictionary *entityCache = self.rzi_cacheByEntityName[NSStringFromClass(entityClass)];
+    NSMutableDictionary *entityCache = self.rzi_cacheByEntity[NSStringFromClass(entityClass)];
     if (entityCache == nil) {
         entityCache = [NSMutableDictionary dictionary];
-        self.rzi_cacheByEntityName[NSStringFromClass(entityClass)] = entityCache;
+        self.rzi_cacheByEntity[NSStringFromClass(entityClass)] = entityCache;
     }
     NSMutableDictionary *entityKeyCache = entityCache[key];
     if (entityKeyCache == nil) {
@@ -135,7 +135,7 @@ static NSString * const kRZVinylImportCacheContextKey = @"RZVinylImportCacheCont
     }
 }
 
-- (void)rzi_cacheAllObjectsForEntityName:(Class)entityClass
+- (void)rzi_cacheAllObjectsForEntity:(Class)entityClass
 {
     NSArray *objects = [entityClass rzv_allInContext:self];
     [self rzi_cacheObjects:objects forEntity:entityClass];
@@ -162,7 +162,7 @@ static NSString * const kRZVinylImportCacheContextKey = @"RZVinylImportCacheCont
 
 - (BOOL)rzi_isCacheEnabledForEntity:(Class)entityClass;
 {
-    return [self.rzi_cacheByEntityName objectForKey:NSStringFromClass(entityClass)] != nil;
+    return [self.rzi_cacheByEntity objectForKey:NSStringFromClass(entityClass)] != nil;
 }
 
 - (void)rzi_disableCacheForEntity:(Class)entityClass
@@ -170,7 +170,7 @@ static NSString * const kRZVinylImportCacheContextKey = @"RZVinylImportCacheCont
     if (!RZVAssertOffMainContext()) {
         return;
     }
-    [self.rzi_cacheByEntityName removeObjectForKey:NSStringFromClass(entityClass)];
+    [self.rzi_cacheByEntity removeObjectForKey:NSStringFromClass(entityClass)];
 }
 
 @end

--- a/Extensions/Private/NSManagedObjectContext+RZImport_private.h
+++ b/Extensions/Private/NSManagedObjectContext+RZImport_private.h
@@ -29,11 +29,7 @@
 
 @interface NSManagedObjectContext (RZImport_private)
 
-/**
- *  Dictionary holding the cache for the entity. This will enable if it
- *  was not enabled.
- */
-- (NSMutableDictionary *)rzi_cacheForEntity:(Class)entityClass;
+- (NSManagedObject *)rzi_objectForEntity:(Class)entityClass fromDictionary:(NSDictionary *)dictionary;
 
 /**
  *  Check to see if the cache is enabled for the specified entity.

--- a/Extensions/Private/NSManagedObjectContext+RZImport_private.h
+++ b/Extensions/Private/NSManagedObjectContext+RZImport_private.h
@@ -29,6 +29,12 @@
 
 @interface NSManagedObjectContext (RZImport_private)
 
+/**
+ *  Look for a cached instance of entityClass that has matching keys in the dictionary.
+ *
+ *  @param entityClass A subclass of NSManagedObject to lookup.
+ *  @param dictionary A dictionary containing values about to be imported.
+ */
 - (NSManagedObject *)rzi_objectForEntity:(Class)entityClass fromDictionary:(NSDictionary *)dictionary;
 
 /**

--- a/Extensions/Private/NSManagedObjectContext+RZImport_private.h
+++ b/Extensions/Private/NSManagedObjectContext+RZImport_private.h
@@ -1,8 +1,9 @@
 //
-//  NSManagedObjectContext+RZImport.h
-//  RZVinyl
+//  NSManagedObjectContext+RZImport_private.h
+//  Pods
 //
-//  Created by Brian King on 1/12/16.
+//  Created by Brian King on 1/18/16.
+//
 //
 //  Copyright 2014 Raizlabs and other contributors
 //  http://raizlabs.com/
@@ -26,38 +27,22 @@
 //  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 //  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-@import CoreData;
-
-@interface NSManagedObjectContext (RZImport)
+@interface NSManagedObjectContext (RZImport_private)
 
 /**
- *  Specify that this managed object context should be used for all subsequent
- *  RZImport operations. This enables RZImport to work with NSObjects containing
- *  NSManagedObjects.
+ *  Dictionary holding the cache for the entity. This will enable if it
+ *  was not enabled.
  */
-- (void)rzi_performImport:(void(^)(void))importBlock;
+- (NSMutableDictionary *)rzi_cacheForEntity:(Class)entityClass;
 
 /**
- *  The managed object context that is being imported to. This is set internally
- *  and by the `rzi_performImport:` method.
+ *  Check to see if the cache is enabled for the specified entity.
  */
-+ (NSManagedObjectContext *)rzi_currentThreadImportContext;
+- (BOOL)rzi_isCacheEnabledForEntity:(Class)entityClass;
 
 /**
- *  Cache all objects that are in the context.
- *
- *  NOTE: If this is called on the main context of the core data stack, this method will assert.
+ *  Disable the cache for the entity.
  */
-- (void)rzi_cacheAllObjectsForEntityName:(Class)entityClass;
-
-/**
- *  Cache a specific set of objects for the given entity.
- *
- *  WARNING: Make sure that the objects cached contain all possibilities for the import
- *  associations, otherwise duplicate objects may be created.
- *
- *  NOTE: If this is called on the main context of the core data stack, this method will assert.
- */
-- (void)rzi_cacheObjects:(NSArray *)objects forEntity:(Class)entityClass;
+- (void)rzi_disableCacheForEntity:(Class)entityClass;
 
 @end

--- a/RZVinyl.podspec
+++ b/RZVinyl.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = "RZVinyl"
-  s.version             = "3.0.0"
+  s.version             = "3.0.1"
   s.summary             = "Stack management, ActiveRecord utilities, and seamless importing for Core Data."
 
   s.description         = <<-DESC
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
     sp.public_header_files = "Extensions/*.h"
     sp.private_header_files = "Extensions/Private/*.h"
     sp.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => 'RZV_IMPORT_AVAILABLE=1'}
-    sp.dependency 'RZImport', '~> 2.0'
+    sp.dependency 'RZImport', '~> 3.0'
   end
     
 end

--- a/RZVinyl.podspec
+++ b/RZVinyl.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = "RZVinyl"
-  s.version             = "2.0.0"
+  s.version             = "3.0.0"
   s.summary             = "Stack management, ActiveRecord utilities, and seamless importing for Core Data."
 
   s.description         = <<-DESC


### PR DESCRIPTION
Enable a shared cache so fetch requests can be performed only once by loading the cache prior to starting the import. The cache is implemented as a set of dictionaries hanging off of the context's `userInfo`. The only public API expansion is `-[NSManagedObjectContext rzi_cacheAllObjectsForEntity:` and `-[NSManagedObjectContext rzi_cacheObjects: forEntity:`.

This should make it very easy to optimize very large data imports.
