### PR TITLE
Add Autorelease Pools to background operation

### DIFF
--- a/Classes/RZCoreDataStack.m
+++ b/Classes/RZCoreDataStack.m
@@ -176,18 +176,22 @@ static RZCoreDataStack *s_defaultStack = nil;
     }
     
     dispatch_async(self.backgroundContextQueue, ^{
-        NSManagedObjectContext *context = [self backgroundManagedObjectContext];
-        [context performBlockAndWait:^{
-            block(context);
-            NSError *err = nil;
-            [context rzv_saveToStoreAndWait:&err];
-            if ( completion ) {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    completion(err);
-                });
-            }
-        }];
-        [self unregisterSaveNotificationsForContext:context];
+        @autoreleasepool {
+            NSManagedObjectContext *context = [self backgroundManagedObjectContext];
+            [context performBlockAndWait:^{
+                NSError *err = nil;
+                @autoreleasepool {
+                    block(context);
+                }
+                [context rzv_saveToStoreAndWait:&err];
+                if ( completion ) {
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        completion(err);
+                    });
+                }
+            }];
+            [self unregisterSaveNotificationsForContext:context];
+        }
     });
 }
 

--- a/Classes/RZCoreDataStack.m
+++ b/Classes/RZCoreDataStack.m
@@ -182,8 +182,8 @@ static RZCoreDataStack *s_defaultStack = nil;
                 NSError *err = nil;
                 @autoreleasepool {
                     block(context);
+                    [context rzv_saveToStoreAndWait:&err];
                 }
-                [context rzv_saveToStoreAndWait:&err];
                 if ( completion ) {
                     dispatch_async(dispatch_get_main_queue(), ^{
                         completion(err);

--- a/Example/RZVinylTests/RZVinylSaveTests.m
+++ b/Example/RZVinylTests/RZVinylSaveTests.m
@@ -28,6 +28,7 @@
 {
     NSURL *storeURL = [[[[self.coreDataStack persistentStoreCoordinator] persistentStores] objectAtIndex:0] URL];
     [[NSFileManager defaultManager] removeItemAtURL:storeURL error:NULL];
+    self.coreDataStack = nil;
     [super tearDown];
 }
 

--- a/Extensions/NSManagedObject+RZImport.m
+++ b/Extensions/NSManagedObject+RZImport.m
@@ -94,7 +94,7 @@
             
             [importedObject rzi_importValuesFromDict:rawDict withMappings:mappings];
             
-            if ( importedObject != nil ) {
+            if ( importedObject != nil && primaryValue != nil ) {
                 [updatedObjects setObject:importedObject forKey:primaryValue];
             }
         }];


### PR DESCRIPTION
Ran into an interesting issue, where the autorelease behavior of the `dispatch_async` auto release pool was not freeing memory in a timely manner. This PR helps with 2 autorelease pools to ensure that any objects internal to core data or created by the user supplied block are released in a timely manner.

I didn't have a great explanation as to why this is needed until I found this:

https://developer.apple.com/library/ios/documentation/General/Conceptual/ConcurrencyProgrammingGuide/OperationQueues/OperationQueues.html#//apple_ref/doc/uid/TP40008091-CH102-SW19

```
Each dispatch queue maintains its own autorelease pool to ensure that autoreleased objects are released at some point; queues make no guarantee about when they actually release those objects.
```

@mgorbach @nbonatsakis 
