### PR TITLE
Warning on NSNull

### DIFF
--- a/Extensions/NSManagedObject+RZImport.m
+++ b/Extensions/NSManagedObject+RZImport.m
@@ -310,7 +310,7 @@
         return;
     }
     
-    if ( value == nil ) {
+    if ( value == nil || value == [NSNull null] ) {
         [self rzi_setNilForPropertyNamed:relationshipInfo.sourcePropertyName];
     }
     else if ( relationshipInfo.isToMany ) {


### PR DESCRIPTION
Currently if you have a nested relationship and "null" comes back from the server it will give a warning message saying "Invalid object class NSNull for…" "…Expecting <some other class>". Pretty sure this is a bug because it causes a lot of noise. 
