### PR TITLE
Error annotations causing swift 3 problems

### DIFF
--- a/Classes/NSManagedObjectContext+RZVinylSave.h
+++ b/Classes/NSManagedObjectContext+RZVinylSave.h
@@ -62,6 +62,6 @@ typedef void (^RZVinylSaveCompletion)(NSError* RZCNullable error);
  *
  *  @return YES if the save succeeded, NO otherwise.
  */
-- (BOOL)rzv_saveToStoreAndWait:(NSError *_Nullable *_Nullable)error;
+- (BOOL)rzv_saveToStoreAndWait:(NSError *RZCNullable *RZCNullable)error;
 
 @end

--- a/Classes/NSManagedObjectContext+RZVinylSave.h
+++ b/Classes/NSManagedObjectContext+RZVinylSave.h
@@ -62,6 +62,6 @@ typedef void (^RZVinylSaveCompletion)(NSError* RZCNullable error);
  *
  *  @return YES if the save succeeded, NO otherwise.
  */
-- (BOOL)rzv_saveToStoreAndWait:(NSError* __autoreleasing RZCNonnull * RZCNullable)error;
+- (BOOL)rzv_saveToStoreAndWait:(NSError **)error;
 
 @end

--- a/Classes/NSManagedObjectContext+RZVinylSave.h
+++ b/Classes/NSManagedObjectContext+RZVinylSave.h
@@ -62,6 +62,6 @@ typedef void (^RZVinylSaveCompletion)(NSError* RZCNullable error);
  *
  *  @return YES if the save succeeded, NO otherwise.
  */
-- (BOOL)rzv_saveToStoreAndWait:(NSError **)error;
+- (BOOL)rzv_saveToStoreAndWait:(NSError *_Nullable *_Nullable)error;
 
 @end

--- a/Classes/NSManagedObjectContext+RZVinylSave.m
+++ b/Classes/NSManagedObjectContext+RZVinylSave.m
@@ -80,7 +80,7 @@ static void rzv_performSaveCompletionAsync(RZVinylSaveCompletion completion, NSE
     }];
 }
 
-- (BOOL)rzv_saveToStoreAndWait:(NSError *__autoreleasing *)error
+- (BOOL)rzv_saveToStoreAndWait:(NSError **)error
 {
     __block NSError *saveErr = nil;
     __block BOOL hasChanges = NO;


### PR DESCRIPTION
These annotations are redundant, because they represent the defaults, and they were causing problems when importing into Swift 3. See https://bugs.swift.org/browse/SR-3207 for details.